### PR TITLE
로그인 페이지 만들기 및 NAV 수정

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -6,7 +6,10 @@ const instance = axios.create({
 });
 
 const getToken = () => {
-  return localStorage.getItem('accessToken');
+  if (typeof window !== 'undefined') {
+    return localStorage.getItem('accessToken');
+  }
+  return null;
 };
 
 interface CustomAxiosRequestConfig {
@@ -14,28 +17,19 @@ interface CustomAxiosRequestConfig {
   headers?: object;
 }
 
-export const getRequest = async (url: string, params: object = {}) => {
+export function getRequest(url: string, params: object = {}) {
+  const config: CustomAxiosRequestConfig = {
+    params
+  };
+
+  return instance.get(url, config);
+}
+
+export const postRequest = async (url: string, data: object) => {
   const token = getToken();
   const config: CustomAxiosRequestConfig = {
-    params,
     headers: token ? { Authorization: `Bearer ${token}` } : {}
   };
-  try {
-    const response = await instance.get(url, config);
-    return response.data;
-  } catch (error) {
-    console.error('Error in GET request:', error);
-    throw new Error('API 요청 실패');
-  }
-};
-
-export const postRequest = async (url: string, data: object, params: object = {}) => {
-  const token = getToken();
-  const config: CustomAxiosRequestConfig = {
-    params,
-    headers: token ? { Authorization: `Bearer ${token}` } : {} // 토큰이 있으면 헤더에 추가
-  };
-
   try {
     const response = await instance.post(url, data, config);
     return response.data;

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -34,7 +34,6 @@ export const postRequest = async (url: string, data: object) => {
     const response = await instance.post(url, data, config);
     return response.data;
   } catch (error) {
-    console.error('Error in POST request:', error);
     throw new Error('API 요청 실패');
   }
 };

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,18 +1,27 @@
-import axios from "axios";
+import axios from 'axios';
 
 const instance = axios.create({
-  baseURL: "http://localhost:3000",
-  timeout: 10000,
+  baseURL: 'http://localhost:3000',
+  timeout: 10000
 });
 
 interface CustomAxiosRequestConfig {
   params?: object;
+  headers?: object;
 }
 
 export function getRequest(url: string, params: object = {}) {
   const config: CustomAxiosRequestConfig = {
-    params,
+    params
   };
 
   return instance.get(url, config);
+}
+
+export function postRequest(url: string, data: object, params: object = {}) {
+  const config: CustomAxiosRequestConfig = {
+    params
+  };
+
+  return instance.post(url, data, config);
 }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -40,16 +40,8 @@ instance.interceptors.response.use(
   }
 );
 
-const getToken = () => {
-  if (typeof window !== 'undefined') {
-    return localStorage.getItem('accessToken');
-  }
-  return null;
-};
-
 interface CustomAxiosRequestConfig {
   params?: object;
-  headers?: object;
 }
 
 export function getRequest(url: string, params: object = {}) {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,9 +1,44 @@
-import axios from 'axios';
+import axios, { AxiosHeaders, type InternalAxiosRequestConfig } from 'axios';
 
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 const instance = axios.create({
-  baseURL: 'http://localhost:3000',
+  baseURL: `${BASE_URL}`,
   timeout: 10000
 });
+
+instance.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('token');
+      if (token) {
+        const headers = new AxiosHeaders(config.headers);
+        headers.set('Authorization', `Bearer ${token}`);
+        config.headers = headers;
+      }
+    }
+    return config;
+  },
+  error => {
+    return Promise.reject(error);
+  }
+);
+instance.interceptors.response.use(
+  res => res,
+  async err => {
+    const request = err.config;
+    if (err.response?.status === 401 && !request._retry) {
+      const refreshToken = localStorage.getItem('refreshToken');
+      if (refreshToken) {
+        await instance.post('/auth/refresh', { refreshToken });
+        request._retry = true;
+        return instance(request);
+      } else {
+        window.location.href = '/signin';
+      }
+    }
+    return Promise.reject(err);
+  }
+);
 
 const getToken = () => {
   if (typeof window !== 'undefined') {
@@ -24,16 +59,14 @@ export function getRequest(url: string, params: object = {}) {
 
   return instance.get(url, config);
 }
+export async function postRequest(url: string, body: object = {}) {
+  return instance.post(url, body);
+}
 
-export const postRequest = async (url: string, data: object) => {
-  const token = getToken();
-  const config: CustomAxiosRequestConfig = {
-    headers: token ? { Authorization: `Bearer ${token}` } : {}
-  };
-  try {
-    const response = await instance.post(url, data, config);
-    return response.data;
-  } catch (error) {
-    throw new Error('API 요청 실패');
-  }
-};
+export async function patchRequest(url: string, body: object = {}) {
+  return instance.patch(url, body);
+}
+
+export async function deleteRequest(url: string) {
+  return instance.delete(url);
+}

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -5,23 +5,42 @@ const instance = axios.create({
   timeout: 10000
 });
 
+const getToken = () => {
+  return localStorage.getItem('accessToken');
+};
+
 interface CustomAxiosRequestConfig {
   params?: object;
   headers?: object;
 }
 
-export function getRequest(url: string, params: object = {}) {
+export const getRequest = async (url: string, params: object = {}) => {
+  const token = getToken();
   const config: CustomAxiosRequestConfig = {
-    params
+    params,
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
+  };
+  try {
+    const response = await instance.get(url, config);
+    return response.data;
+  } catch (error) {
+    console.error('Error in GET request:', error);
+    throw new Error('API 요청 실패');
+  }
+};
+
+export const postRequest = async (url: string, data: object, params: object = {}) => {
+  const token = getToken();
+  const config: CustomAxiosRequestConfig = {
+    params,
+    headers: token ? { Authorization: `Bearer ${token}` } : {} // 토큰이 있으면 헤더에 추가
   };
 
-  return instance.get(url, config);
-}
-
-export function postRequest(url: string, data: object, params: object = {}) {
-  const config: CustomAxiosRequestConfig = {
-    params
-  };
-
-  return instance.post(url, data, config);
-}
+  try {
+    const response = await instance.post(url, data, config);
+    return response.data;
+  } catch (error) {
+    console.error('Error in POST request:', error);
+    throw new Error('API 요청 실패');
+  }
+};

--- a/src/api/signService.ts
+++ b/src/api/signService.ts
@@ -1,0 +1,21 @@
+import type { AxiosResponse } from 'axios';
+import { postRequest } from './api';
+
+// POST 요청을 처리하는 함수 (자세한 구현은 아래 참조)
+
+export const signIn = async (email: string, password: string) => {
+  try {
+    const response: AxiosResponse<any> = await postRequest('http://15.165.57.191/auth/signIn', {
+      email,
+      password
+    });
+
+    if (response.status === 200) {
+      return response.data;
+    } else {
+      throw new Error('Login failed');
+    }
+  } catch (error) {
+    throw new Error('An error occurred during login.');
+  }
+};

--- a/src/api/signService.ts
+++ b/src/api/signService.ts
@@ -16,11 +16,9 @@ export const signIn = async (credentials: LoginCredentials) => {
     }
 
     localStorage.setItem('accessToken', response.accessToken);
-    console.log('토큰토큰토큰: ', localStorage.getItem('accessToken'));
 
     return response;
   } catch (error) {
-    console.error('Error in signIn:', error);
     throw new Error('Login failed');
   }
 };

--- a/src/api/signService.ts
+++ b/src/api/signService.ts
@@ -10,12 +10,12 @@ export const signIn = async (email: string, password: string) => {
       password
     });
 
-    if (response.status === 200) {
-      return response.data;
-    } else {
-      throw new Error('Login failed');
-    }
+    const { accessToken } = response.data;
+    localStorage.setItem('accessToken', accessToken);
+
+    return response.data;
   } catch (error) {
-    throw new Error('An error occurred during login.');
+    console.error('Login failed:', error);
+    throw new Error('로그인 실패');
   }
 };

--- a/src/api/signService.ts
+++ b/src/api/signService.ts
@@ -11,13 +11,9 @@ export const signIn = async (credentials: LoginCredentials) => {
   try {
     const response = await postRequest(url, credentials);
 
-    if (!response.accessToken || !response.role) {
-      throw new Error('Invalid API response: Missing required fields');
-    }
+    localStorage.setItem('accessToken', response.data.accessToken);
 
-    localStorage.setItem('accessToken', response.accessToken);
-
-    return response;
+    return response.data;
   } catch (error) {
     throw new Error('Login failed');
   }

--- a/src/api/signService.ts
+++ b/src/api/signService.ts
@@ -1,21 +1,26 @@
-import type { AxiosResponse } from 'axios';
 import { postRequest } from './api';
 
-// POST 요청을 처리하는 함수 (자세한 구현은 아래 참조)
+interface LoginCredentials {
+  email: string;
+  password: string;
+}
 
-export const signIn = async (email: string, password: string) => {
+export const signIn = async (credentials: LoginCredentials) => {
+  const url = 'http://15.165.57.191/auth/signIn';
+
   try {
-    const response: AxiosResponse<any> = await postRequest('http://15.165.57.191/auth/signIn', {
-      email,
-      password
-    });
+    const response = await postRequest(url, credentials);
 
-    const { accessToken } = response.data;
-    localStorage.setItem('accessToken', accessToken);
+    if (!response.accessToken || !response.role) {
+      throw new Error('Invalid API response: Missing required fields');
+    }
 
-    return response.data;
+    localStorage.setItem('accessToken', response.accessToken);
+    console.log('토큰토큰토큰: ', localStorage.getItem('accessToken'));
+
+    return response;
   } catch (error) {
-    console.error('Login failed:', error);
-    throw new Error('로그인 실패');
+    console.error('Error in signIn:', error);
+    throw new Error('Login failed');
   }
 };

--- a/src/api/signService.ts
+++ b/src/api/signService.ts
@@ -6,10 +6,10 @@ interface LoginCredentials {
 }
 
 export const signIn = async (credentials: LoginCredentials) => {
-  const url = 'http://15.165.57.191/auth/signIn';
+  const endpoint = '/auth/signIn';
 
   try {
-    const response = await postRequest(url, credentials);
+    const response = await postRequest(endpoint, credentials);
 
     localStorage.setItem('accessToken', response.data.accessToken);
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
+// app/layout.tsx
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import Nav from '@/components/Nav/Nav';
+import { UserProvider, useUserStatus } from '@/context/UserContext';
 import '../styles/globals.css';
 
 const pretendard = localFont({
@@ -25,8 +27,10 @@ export default function RootLayout({
         <link rel="icon" href="/favicon.ico" sizes="any" />
       </head>
       <body className={pretendard.className}>
-        <Nav userStatus="loggedOut" />
-        <div className="min-h-screen bg-gray-50">{children}</div>
+        <UserProvider>
+          <Nav />
+          <div className="min-h-screen bg-gray-50">{children}</div>
+        </UserProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ export default async function Home() {
           <Image src={pcLogo} alt="HanCook Logo" width={462} height={92.4} />
           <p className="text-[2rem] font-semibold text-color-700">Capture and share your Hansik(Korean Food) cooking!</p>
         </div>
-        <Cta url="/signin">Go to Sign-in</Cta>
+        <Cta url="/signIn">Go to Sign-in</Cta>
       </div>
     </div>
   );

--- a/src/app/signIn/page.tsx
+++ b/src/app/signIn/page.tsx
@@ -1,0 +1,5 @@
+import SignIn from '@/components/ClientWrapper/SignInClient';
+
+export default function SignInPage() {
+  return <SignIn />;
+}

--- a/src/components/ClientWrapper/SignInClient.tsx
+++ b/src/components/ClientWrapper/SignInClient.tsx
@@ -21,10 +21,10 @@ export default function SignIn() {
     event.preventDefault();
     try {
       const credentials = { email, password };
-      const response = await signIn(credentials);
-      if (response.role === 'admin') {
+      const res = await signIn(credentials);
+      if (res.role === 'admin') {
         setUserStatus('admin');
-      } else if (response.role === 'normal') {
+      } else if (res.role === 'normal') {
         setUserStatus('normal');
       }
       router.push('/recipeList');

--- a/src/components/ClientWrapper/SignInClient.tsx
+++ b/src/components/ClientWrapper/SignInClient.tsx
@@ -2,70 +2,69 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import logoImg from '@/../public/assets/img_logo_pc.png';
+import { signIn } from '@/api/signService';
 import SignInput from '../Input/SignInput';
 
 export default function SignIn() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [emailError, setEmailError] = useState('');
+  const router = useRouter();
 
   const isValidEmail = (email: string) => /\S+@\S+\.\S+/.test(email);
   const isFormValid = isValidEmail(email) && password.length >= 6;
 
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
-  };
 
-  const handleEmailBlur = () => {
-    if (!isValidEmail(email)) {
-      setEmailError('잘못된 이메일입니다.');
-    } else {
-      setEmailError('');
-    }
+    try {
+      const response = await signIn(email, password);
+      localStorage.setItem('accessToken', response.accessToken);
+      router.push('/recipeList');
+    } catch (err) {}
   };
 
   return (
-    <div className="">
-      <div className="flex justify-center ">
-        <Image src={logoImg} alt="로고 이미지" className="mt-[12rem]" />
-      </div>
-      <form onSubmit={handleSignIn}>
-        <SignInput
-          type="email"
-          label="Email"
-          placeholder="Please enter your email"
-          value={email}
-          onChange={e => setEmail(e.target.value)}
-          onBlur={handleEmailBlur}
-          required
-        />
-        {emailError && <p className="text-red-500 text-sm mt-2">{emailError}</p>}
-        <SignInput
-          type="password"
-          label="Password"
-          placeholder="Please enter your password"
-          value={password}
-          onChange={e => setPassword(e.target.value)}
-          required
-        />
-        <button
-          type="submit"
-          className={`w-full text-primary-white border rounded-[0.8rem] text-center ${
-            isFormValid ? 'bg-primary-beige' : 'bg-gray-400 cursor-not-allowed'
-          }`}
-          disabled={!isFormValid}
-        >
-          Sign In
-        </button>
-        <p>Not a member yet?</p>
-      </form>
-      <div className="flex justify-center gap-[1rem] mt-[2rem]">
-        <p className="text-[1.6rem] font-normal text-gray-600">Do you have an account?</p>
-        <Link className="text-[1.6rem] font-normal text-gray-800" href="/signUp">
-          Sign up now
-        </Link>
+    <div className="flex justify-center items-center">
+      <div className="flex flex-col w-[51.8rem]">
+        <div className="flex justify-center">
+          <Image src={logoImg} alt="로고 이미지" className="mt-[12.7rem] mb-[4rem]" />
+        </div>
+        <form onSubmit={handleSignIn}>
+          <SignInput
+            type="email"
+            label="Email"
+            placeholder="Please enter your email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+          <SignInput
+            type="password"
+            label="Password"
+            placeholder="Please enter your password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+          <button
+            type="submit"
+            className={`w-full h-[4.8rem] text-[1.6rem] text-primary-white border rounded-[0.8rem] text-center ${
+              isFormValid ? 'bg-primary-beige' : 'bg-gray-400 cursor-not-allowed'
+            }`}
+            disabled={!isFormValid}
+          >
+            Sign In
+          </button>
+        </form>
+        <div className="flex justify-center gap-[1rem] mt-[2rem]">
+          <p className="text-[1.6rem] font-normal text-gray-600">Not a member yet?</p>
+          <Link className="text-[1.6rem] font-normal text-gray-800 underline" href="/signUp">
+            Sign up now
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ClientWrapper/SignInClient.tsx
+++ b/src/components/ClientWrapper/SignInClient.tsx
@@ -22,7 +22,6 @@ export default function SignIn() {
     try {
       const credentials = { email, password };
       const response = await signIn(credentials);
-      console.log('Login successful:', response);
       if (response.role === 'admin') {
         setUserStatus('admin');
       } else if (response.role === 'normal') {

--- a/src/components/ClientWrapper/SignInClient.tsx
+++ b/src/components/ClientWrapper/SignInClient.tsx
@@ -1,43 +1,72 @@
 'use client';
 
+import Image from 'next/image';
+import Link from 'next/link';
 import { useState } from 'react';
+import logoImg from '@/../public/assets/img_logo_pc.png';
 import SignInput from '../Input/SignInput';
 
 export default function SignIn() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [emailError, setEmailError] = useState('');
+
+  const isValidEmail = (email: string) => /\S+@\S+\.\S+/.test(email);
+  const isFormValid = isValidEmail(email) && password.length >= 6;
 
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
   };
 
+  const handleEmailBlur = () => {
+    if (!isValidEmail(email)) {
+      setEmailError('잘못된 이메일입니다.');
+    } else {
+      setEmailError('');
+    }
+  };
+
   return (
-    <div className="max-w-md mx-auto mt-10 p-6 bg-white shadow-md rounded-lg">
+    <div className="">
+      <div className="flex justify-center ">
+        <Image src={logoImg} alt="로고 이미지" className="mt-[12rem]" />
+      </div>
       <form onSubmit={handleSignIn}>
         <SignInput
           type="email"
-          label="Email Address"
-          placeholder="Enter your email"
+          label="Email"
+          placeholder="Please enter your email"
           value={email}
           onChange={e => setEmail(e.target.value)}
+          onBlur={handleEmailBlur}
           required
         />
+        {emailError && <p className="text-red-500 text-sm mt-2">{emailError}</p>}
         <SignInput
           type="password"
           label="Password"
-          placeholder="Enter your password"
+          placeholder="Please enter your password"
           value={password}
           onChange={e => setPassword(e.target.value)}
           required
         />
         <button
           type="submit"
-          className="w-full bg-blue-500 text-white py-2 px-4 rounded-lg hover:bg-blue-600 transition-colors text-sm"
+          className={`w-full text-primary-white border rounded-[0.8rem] text-center ${
+            isFormValid ? 'bg-primary-beige' : 'bg-gray-400 cursor-not-allowed'
+          }`}
+          disabled={!isFormValid}
         >
           Sign In
         </button>
-        <p>Not a member yet? Sign up now</p>
+        <p>Not a member yet?</p>
       </form>
+      <div className="flex justify-center gap-[1rem] mt-[2rem]">
+        <p className="text-[1.6rem] font-normal text-gray-600">Do you have an account?</p>
+        <Link className="text-[1.6rem] font-normal text-gray-800" href="/signUp">
+          Sign up now
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/components/ClientWrapper/SignInClient.tsx
+++ b/src/components/ClientWrapper/SignInClient.tsx
@@ -6,22 +6,28 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import logoImg from '@/../public/assets/img_logo_pc.png';
 import { signIn } from '@/api/signService';
+import { useUserStatus } from '@/context/UserContext';
 import SignInput from '../Input/SignInput';
 
 export default function SignIn() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const { setUserStatus } = useUserStatus();
   const router = useRouter();
 
   const isValidEmail = (email: string) => /\S+@\S+\.\S+/.test(email);
   const isFormValid = isValidEmail(email) && password.length >= 6;
-
-  const handleSignIn = async (e: React.FormEvent) => {
-    e.preventDefault();
-
+  const handleSignIn = async (event: React.FormEvent) => {
+    event.preventDefault();
     try {
-      const response = await signIn(email, password);
-      localStorage.setItem('accessToken', response.accessToken);
+      const credentials = { email, password };
+      const response = await signIn(credentials);
+      console.log('Login successful:', response);
+      if (response.role === 'admin') {
+        setUserStatus('admin');
+      } else if (response.role === 'normal') {
+        setUserStatus('normal');
+      }
       router.push('/recipeList');
     } catch (err) {}
   };

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -34,7 +34,7 @@ export default function Nav() {
         <div className="w-[120rem] flex justify-between items-center">
           <div className="gap-[2.4rem] flex items-center justify-center">
             <Image
-              className="w-[14.6rem] h-[2.92rem]"
+              className="w-[14.6rem] h-[2.92rem] cursor-pointer"
               src={logo}
               alt="로고"
               onClick={() => {
@@ -50,23 +50,20 @@ export default function Nav() {
               {userStatus !== 'loggedOut' && (
                 <>
                   <p
-                    className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem]
-                ${isRecipe ? 'text-primary-blue' : 'text-gray-600'}`}
+                    className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem] cursor-pointer ${isRecipe ? 'text-primary-blue' : 'text-gray-600'}`}
                     onClick={() => router.push('/recipeList')}
                   >
                     Recipe
                   </p>
                   <p
-                    className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem]
-                ${isChallenge ? 'text-primary-blue' : 'text-gray-600'}`}
+                    className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem] cursor-pointer  ${isChallenge ? 'text-primary-blue' : 'text-gray-600'}`}
                     onClick={() => router.push('/challengeList')}
                   >
                     Challenge
                   </p>
                   {userStatus === 'admin' && (
                     <p
-                      className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem]
-                ${isMgmt ? 'text-primary-blue' : 'text-gray-600'}`}
+                      className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem] cursor-pointer ${isMgmt ? 'text-primary-blue' : 'text-gray-600'}`}
                       onClick={() => router.push('/management')}
                     >
                       Mgmt.
@@ -83,7 +80,7 @@ export default function Nav() {
                 <Image src={bell} alt="벨" />
                 <Image src={userProfile} alt="프로필" />
                 <button
-                  className="flex rounded-[0.8rem] px-[2.4rem] py-[1.1rem] gap-[1rem] bg-primary-blue font-semibold text-[1.6rem] leading-[1.909rem] text-[#ffffff]"
+                  className="flex rounded-[0.8rem] px-[2.4rem] py-[1.1rem] gap-[1rem] bg-primary-blue font-semibold text-[1.6rem] leading-[1.909rem] text-primary-white"
                   onClick={handleSignOut}
                 >
                   Log Out
@@ -93,7 +90,7 @@ export default function Nav() {
               <>
                 <Image src={adminProfile} alt="프로필" />
                 <button
-                  className="flex rounded-[0.8rem] px-[2.4rem] py-[1.1rem] gap-[1rem] bg-primary-blue font-semibold text-[1.6rem] leading-[1.909rem] text-[#ffffff]"
+                  className="flex rounded-[0.8rem] px-[2.4rem] py-[1.1rem] gap-[1rem] bg-primary-blue font-semibold text-[1.6rem] leading-[1.909rem] text-primary-white"
                   onClick={handleSignOut}
                 >
                   Log Out
@@ -101,7 +98,7 @@ export default function Nav() {
               </>
             ) : (
               <button
-                className="flex rounded-[0.8rem] px-[2.4rem] py-[1.1rem] gap-[1rem] bg-primary-blue font-semibold text-[1.6rem] leading-[1.909rem] text-[#ffffff]"
+                className="flex rounded-[0.8rem] px-[2.4rem] py-[1.1rem] gap-[1rem] bg-primary-blue font-semibold text-[1.6rem] leading-[1.909rem] text-primary-white"
                 onClick={() => router.push('/signIn')}
               >
                 Sign in

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -9,7 +9,6 @@ import logo from '@/../public/assets/img_logo_pc.png';
 import adminProfile from '@/../public/assets/img_profile_admin.png';
 import userProfile from '@/../public/assets/img_profile_member.png';
 import { useUserStatus } from '@/context/UserContext';
-import type { NavProps } from '@/interfaces/navInterface';
 import { logout } from '@/utils/auth';
 import ClosableModalClient from '../ClientWrapper/ClosableModalClient';
 
@@ -25,8 +24,8 @@ export default function Nav() {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleSignOut = () => {
-    setUserStatus('loggedOut'); // 로그아웃 상태로 설정
-    router.push('/signIn'); // 로그인 페이지로 리디렉션
+    setUserStatus('loggedOut');
+    logout();
   };
 
   return (

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -8,10 +8,13 @@ import translate from '@/../public/assets/icon_translate.png';
 import logo from '@/../public/assets/img_logo_pc.png';
 import adminProfile from '@/../public/assets/img_profile_admin.png';
 import userProfile from '@/../public/assets/img_profile_member.png';
+import { useUserStatus } from '@/context/UserContext';
 import type { NavProps } from '@/interfaces/navInterface';
+import { logout } from '@/utils/auth';
 import ClosableModalClient from '../ClientWrapper/ClosableModalClient';
 
-export default function Nav({ userStatus = 'loggedOut' }: NavProps) {
+export default function Nav() {
+  const { userStatus, setUserStatus } = useUserStatus();
   const router = useRouter();
   const pathname = usePathname();
 
@@ -21,49 +24,82 @@ export default function Nav({ userStatus = 'loggedOut' }: NavProps) {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  const handleSignOut = () => {
+    setUserStatus('loggedOut'); // 로그아웃 상태로 설정
+    router.push('/signIn'); // 로그인 페이지로 리디렉션
+  };
+
   return (
     <div className="w-full h-full flex">
       <div className="flex w-full h-[6rem] justify-center items-center border-b border-gray-100">
         <div className="w-[120rem] flex justify-between items-center">
           <div className="gap-[2.4rem] flex items-center justify-center">
-            <Image className="w-[14.6rem] h-[2.92rem]" src={logo} alt="로고" onClick={() => router.push('/')} />
+            <Image
+              className="w-[14.6rem] h-[2.92rem]"
+              src={logo}
+              alt="로고"
+              onClick={() => {
+                if (userStatus !== 'loggedOut') {
+                  router.push('/recipeList');
+                } else {
+                  router.push('/');
+                }
+              }}
+            />
+
             <div className="flex">
-              <p
-                className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem]
+              {userStatus !== 'loggedOut' && (
+                <>
+                  <p
+                    className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem]
                 ${isRecipe ? 'text-primary-blue' : 'text-gray-600'}`}
-                onClick={() => router.push('/recipeList')}
-              >
-                Recipe
-              </p>
-              <p
-                className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem]
+                    onClick={() => router.push('/recipeList')}
+                  >
+                    Recipe
+                  </p>
+                  <p
+                    className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem]
                 ${isChallenge ? 'text-primary-blue' : 'text-gray-600'}`}
-                onClick={() => router.push('/challengeList')}
-              >
-                Challenge
-              </p>
-              {userStatus === 'adminUser' ? (
-                <p
-                  className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem]
+                    onClick={() => router.push('/challengeList')}
+                  >
+                    Challenge
+                  </p>
+                  {userStatus === 'admin' && (
+                    <p
+                      className={`flex items-center justify-center py-[2.1rem] px-[1.7rem] gap-[1rem] font-semibold leading-[1.79rem] text-[1.5rem]
                 ${isMgmt ? 'text-primary-blue' : 'text-gray-600'}`}
-                  onClick={() => router.push('/management')}
-                >
-                  Mgmt.
-                </p>
-              ) : (
-                ''
+                      onClick={() => router.push('/management')}
+                    >
+                      Mgmt.
+                    </p>
+                  )}
+                </>
               )}
             </div>
           </div>
           <div className="flex gap-[1.6rem] items-center justify-center cursor-pointer">
             <Image src={translate} alt="번역" onClick={() => setIsModalOpen(true)} />
-            {userStatus === 'generalUser' ? (
+            {userStatus === 'normal' ? (
               <>
                 <Image src={bell} alt="벨" />
                 <Image src={userProfile} alt="프로필" />
+                <button
+                  className="flex rounded-[0.8rem] px-[2.4rem] py-[1.1rem] gap-[1rem] bg-primary-blue font-semibold text-[1.6rem] leading-[1.909rem] text-[#ffffff]"
+                  onClick={handleSignOut}
+                >
+                  Log Out
+                </button>
               </>
-            ) : userStatus === 'adminUser' ? (
-              <Image src={adminProfile} alt="프로필" />
+            ) : userStatus === 'admin' ? (
+              <>
+                <Image src={adminProfile} alt="프로필" />
+                <button
+                  className="flex rounded-[0.8rem] px-[2.4rem] py-[1.1rem] gap-[1rem] bg-primary-blue font-semibold text-[1.6rem] leading-[1.909rem] text-[#ffffff]"
+                  onClick={handleSignOut}
+                >
+                  Log Out
+                </button>
+              </>
             ) : (
               <button
                 className="flex rounded-[0.8rem] px-[2.4rem] py-[1.1rem] gap-[1rem] bg-primary-blue font-semibold text-[1.6rem] leading-[1.909rem] text-[#ffffff]"

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { type ReactNode, createContext, useContext, useState } from 'react';
+
+type UserStatus = 'loggedOut' | 'normal' | 'admin';
+
+interface UserContextType {
+  userStatus: UserStatus;
+  setUserStatus: (status: UserStatus) => void;
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const [userStatus, setUserStatus] = useState<UserStatus>('loggedOut');
+
+  const login = (role: UserStatus) => {
+    setUserStatus(role);
+  };
+
+  return <UserContext.Provider value={{ userStatus, setUserStatus: login }}>{children}</UserContext.Provider>;
+}
+
+export function useUserStatus() {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUserStatus must be used within a UserProvider');
+  }
+  return context;
+}

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,13 +1,7 @@
 'use client';
 
 import { type ReactNode, createContext, useContext, useState } from 'react';
-
-type UserStatus = 'loggedOut' | 'normal' | 'admin';
-
-interface UserContextType {
-  userStatus: UserStatus;
-  setUserStatus: (status: UserStatus) => void;
-}
+import type { UserContextType, UserStatus } from '@/interfaces/userContextInterface';
 
 const UserContext = createContext<UserContextType | undefined>(undefined);
 

--- a/src/interfaces/navInterface.ts
+++ b/src/interfaces/navInterface.ts
@@ -1,3 +1,0 @@
-export interface NavProps {
-  userStatus: 'loggedOut' | 'generalUser' | 'adminUser';
-}

--- a/src/interfaces/userContextInterface.ts
+++ b/src/interfaces/userContextInterface.ts
@@ -1,0 +1,6 @@
+export type UserStatus = 'loggedOut' | 'normal' | 'admin';
+
+export interface UserContextType {
+  userStatus: UserStatus;
+  setUserStatus: (status: UserStatus) => void;
+}

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,4 @@
+export const logout = () => {
+  localStorage.removeItem('accessToken');
+  window.location.href = '/';
+};


### PR DESCRIPTION
## 이슈 번호

- close #92 

## 작업 사항
1. 로그아웃 상태일때
![Screenshot 2024-11-23 at 15 28 08](https://github.com/user-attachments/assets/1903864e-1a70-4cd3-8a5e-879c8c1b5d7c)
2. 일반 유저 로그인
![Screenshot 2024-11-23 at 15 28 30](https://github.com/user-attachments/assets/b5eb66c7-b484-4590-be43-32c88e580cf8)
3. 어드민 유저 로그인
![Screenshot 2024-11-23 at 15 42 49](https://github.com/user-attachments/assets/eabebe49-7140-49bc-8b6f-f50c9ee1f806)
4. 로그인 페이지
![Screenshot 2024-11-23 at 15 28 15](https://github.com/user-attachments/assets/c859271a-b39b-4367-95c2-5ad11e855866)

- [x] SingInClient.tsx 완성 시키기.
  - 타이틀
  - validation
  - 폼 제출 버튼
  - 버튼 아래 글
- [x] 페이지 연동 - API 연결
- [x] token 이용해서 nav바 다루기
  - 로그인 상태 -> 랜딩 페이지 접속 X
  - 일반 유저 로그인 -> 레시피, 챌린지, 번역, 알림, 프로필, 로그아웃
  - 어드민 유저 로그인 -> 레시피, 챌린지, mgmt, 번역, 왕관프로필, 로그아웃
  - css 수정
- [x] 로그아웃 버튼 만들기
  - 토큰 삭제

## 기타
작업을 이슈 나눠서 했어야 했는데 어쩌다보니 너무 많이 몰아서 해버렸습니다. 죄송합니다 !
- 로그인하면 /recipeList 로 가게 만듦.