### PR TITLE
챌린지 리스트 전반적인 수정 (+ 토큰 관련, API 관련)

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -9,7 +9,7 @@ const instance = axios.create({
 instance.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     if (typeof window !== 'undefined') {
-      const token = localStorage.getItem('token');
+      const token = localStorage.getItem('accessToken');
       console.log(token);
       if (token) {
         const headers = new AxiosHeaders(config.headers);
@@ -56,7 +56,6 @@ export async function postRequest(url: string, body: object = {}, options: { hea
   };
 
   const headers = { ...defaultHeaders, ...options.headers };
-  console.log({ headers });
 
   return instance.post(url, body, { headers });
 }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -10,11 +10,8 @@ instance.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     if (typeof window !== 'undefined') {
       const token = localStorage.getItem('accessToken');
-      console.log(token);
       if (token) {
-        const headers = new AxiosHeaders(config.headers);
-        headers.set('Authorization', `Bearer ${token}`);
-        config.headers = headers;
+        config.headers['Authorization'] = `Bearer ${token}`;
       }
     }
     return config;
@@ -34,7 +31,7 @@ instance.interceptors.response.use(
         request._retry = true;
         return instance(request);
       } else {
-        window.location.href = '/signin';
+        window.location.href = '/signIn';
       }
     }
     return Promise.reject(err);
@@ -50,14 +47,8 @@ export function getRequest(url: string, params: object = {}) {
   };
   return instance.get(url, config);
 }
-export async function postRequest(url: string, body: object = {}, options: { headers?: Record<string, string> } = {}) {
-  const defaultHeaders = {
-    'Content-Type': 'application/json'
-  };
-
-  const headers = { ...defaultHeaders, ...options.headers };
-
-  return instance.post(url, body, { headers });
+export async function postRequest(url: string, body: object = {}) {
+  return instance.post(url, body);
 }
 
 export async function patchRequest(url: string, body: object = {}) {

--- a/src/api/challengeService.ts
+++ b/src/api/challengeService.ts
@@ -37,14 +37,12 @@ export const fetchChallengeStatus = async (id: string, page: number): Promise<Ch
 
 export const fetchChallengeRequest = async (data: object, token: string) => {
   try {
-    console.log(token);
     const response = await postRequest('/challenges', data, {
       headers: {
         Authorization: `Bearer ${token}`
       }
     });
 
-    console.log('API Response Data:', response.data);
     return response.data;
   } catch (err: any) {
     let errorMessage = 'An unexpected error occurred. Please try again.';

--- a/src/api/challengeService.ts
+++ b/src/api/challengeService.ts
@@ -11,6 +11,13 @@ export const fetchChallenge = async () => {
   return response.data;
 };
 
+export const getFilteredChallenges = async () => {
+  const { list, totalCount } = await fetchChallenge();
+  const filteredList = list.filter((list: { status: string }) => ['onGoing', 'finished'].includes(list.status));
+
+  return { list: filteredList, totalCount };
+};
+
 export const fetchRanker = async () => {
   const response = await getRequest('http://localhost:3000/rankerMockData.json');
   return response.data;

--- a/src/api/challengeService.ts
+++ b/src/api/challengeService.ts
@@ -35,13 +35,9 @@ export const fetchChallengeStatus = async (id: string, page: number): Promise<Ch
   return response.data;
 };
 
-export const fetchChallengeRequest = async (data: object, token: string) => {
+export const fetchChallengeRequest = async (data: object) => {
   try {
-    const response = await postRequest('/challenges', data, {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    });
+    const response = await postRequest('/challenges', data);
 
     return response.data;
   } catch (err: any) {

--- a/src/app/challengeList/page.tsx
+++ b/src/app/challengeList/page.tsx
@@ -1,10 +1,11 @@
-import { fetchAdminChallenge, fetchChallenge, fetchRanker } from '@/api/challengeService';
+import { fetchAdminChallenge, fetchChallenge, fetchRanker, getFilteredChallenges } from '@/api/challengeService';
 import ChallengeListClient from '@/components/ClientWrapper/ChallengeListClient';
 
 export default async function ChallengeListPage() {
   const adminchallengeData = await fetchAdminChallenge();
-  const { list, totalCount } = await fetchChallenge();
+  const { list, totalCount } = await getFilteredChallenges();
   const rankerData = await fetchRanker();
+
   const Data = {
     adminchallengeData,
     list,

--- a/src/components/ClientWrapper/ChallengeListClient.tsx
+++ b/src/components/ClientWrapper/ChallengeListClient.tsx
@@ -55,13 +55,19 @@ export default function ChallengeListClient({ adminchallengeData, challengeData,
           <p className="font-semibold text-[2rem] leading-[2.387rem] text-gray-800 pt-[2rem] pb-[2.4rem]">
             This Month's Challenge
           </p>
-          <div className="flex gap-[2.55rem]">
-            {adminchallengeData.map((data, index) => (
-              <div key={index} onClick={() => handleChallengeClick(data.id)} className="cursor-pointer">
-                <MonthlyChallengeCard data={data} role={role} />
-              </div>
-            ))}
-          </div>
+          {adminchallengeData.length > 0 ? (
+            <div className="flex gap-[2.55rem]">
+              {adminchallengeData.map((data, index) => (
+                <div key={index} onClick={() => handleChallengeClick(data.id)} className="cursor-pointer">
+                  <MonthlyChallengeCard data={data} role={role} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex items-center justify-center h-[18rem]">
+              <p className="font-normal text-[1.6rem] leading-[2.387rem] text-gray-500">There’s no challenge in running ...</p>
+            </div>
+          )}
         </div>
         <div className="flex justify-between items-center mt-[4rem] mb-[2.4rem]">
           <p className="font-semibold text-[2rem] leading-[2.387rem text-gray-800">Challenge List</p>
@@ -81,13 +87,20 @@ export default function ChallengeListClient({ adminchallengeData, challengeData,
             </button>
           </div>
         </div>
-        <div className="flex justify-between grid grid-cols-2 grid-rows-2 gap-[2.4rem]">
-          {mediumItems.map((data, index) => (
-            <div key={index} onClick={() => handleChallengeClick(data.id)} className="cursor-pointer">
-              <ChallengeCard data={data} userId={userId} role={role} />
-            </div>
-          ))}
-        </div>
+        {mediumItems.length > 0 ? (
+          <div className="flex justify-between grid grid-cols-2 grid-rows-2 gap-[2.4rem]">
+            {mediumItems.map((data, index) => (
+              <div key={index} onClick={() => handleChallengeClick(data.id)} className="cursor-pointer">
+                <ChallengeCard data={data} userId={userId} role={role} />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center h-[35rem]">
+            <p className="font-normal text-[1.6rem] leading-[2.387rem] text-gray-500">There’s no challenge in running,</p>
+            <p className="font-normal text-[1.6rem] leading-[2.387rem] text-gray-500">Let’s get it started!</p>
+          </div>
+        )}
       </div>
       <div className="mt-[4rem] mb-[2.4rem]">
         <Pagination

--- a/src/components/ClientWrapper/ChallengeRequestClient.tsx
+++ b/src/components/ClientWrapper/ChallengeRequestClient.tsx
@@ -6,13 +6,10 @@ import { useRef, useState } from 'react';
 import plus from '@/../public/assets/icon_add_photo_plus.png';
 import close from '@/../public/assets/icon_out_circle_small.png';
 import { fetchChallengeRequest } from '@/api/challengeService';
-import useStore from '@/store/store';
 import ChallengeApplyDropdown from '../Dropdown/ChallengeApplyDropdown';
 import DateDropdown from '../Dropdown/DateDropdown';
 
 export default function ChallengeRequestClient() {
-  const { accessToken } = useStore();
-
   const router = useRouter();
   const [title, setTitle] = useState('');
   const [titleError, setTitleError] = useState(false);
@@ -106,12 +103,7 @@ export default function ChallengeRequestClient() {
     };
 
     try {
-      if (!accessToken) {
-        alert('User is not authenticated.');
-        return;
-      }
-
-      const res = await fetchChallengeRequest(data, accessToken);
+      const res = await fetchChallengeRequest(data);
       const { challenge, uploadUrls } = res;
       const uploadResults = await Promise.all(
         images.map(async (image, index) => {
@@ -140,7 +132,6 @@ export default function ChallengeRequestClient() {
                 index
               };
             }
-
             return {
               success: true,
               index
@@ -154,14 +145,12 @@ export default function ChallengeRequestClient() {
           }
         })
       );
-
       const failedUploads = uploadResults.filter(result => !result.success);
       if (failedUploads.length > 0) {
         alert('Some images failed to upload. Please try again.');
         return;
       }
-
-      alert('Form submitted successfully!');
+      alert('Request a Challenge Successfully!');
       router.push('/challengeList');
     } catch (error) {
       alert('Error submitting the form. Please try again.');

--- a/src/components/ClientWrapper/SignInClient.tsx
+++ b/src/components/ClientWrapper/SignInClient.tsx
@@ -22,9 +22,10 @@ export default function SignIn() {
     try {
       const credentials = { email, password };
       const res = await signIn(credentials);
+      localStorage.setItem('accessToken', res.accessToken);
 
       const { login } = useStore.getState();
-      login(res.userId, res.role, res.accessToken);
+      login(res.userId, res.role);
 
       router.push('/challengeList');
     } catch (err: any) {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -20,8 +20,7 @@ interface StoreState {
   userStatus: 'loggedOut' | 'normal' | 'admin';
   userId: string | null;
   role: 'normal' | 'admin' | null;
-  accessToken: string | null;
-  login: (userId: string, role: 'normal' | 'admin', accessToken: string) => void;
+  login: (userId: string, role: 'normal' | 'admin') => void;
   logout: () => void;
   setUserStatus: (status: 'loggedOut' | 'normal' | 'admin') => void;
 }
@@ -29,7 +28,6 @@ interface StoreState {
 const useStore = create<StoreState>((set: (partial: Partial<StoreState>) => void) => {
   const storedUserId = localStorage.getItem('userId');
   const storedRole = localStorage.getItem('role') as 'normal' | 'admin' | null;
-  const storedToken = localStorage.getItem('accessToken');
   const initialUserStatus = storedRole === 'admin' ? 'admin' : storedRole === 'normal' ? 'normal' : 'loggedOut';
 
   return {
@@ -53,14 +51,11 @@ const useStore = create<StoreState>((set: (partial: Partial<StoreState>) => void
     userStatus: initialUserStatus,
     userId: storedUserId || null,
     role: storedRole || null,
-    accessToken: storedToken || null,
 
-    login: (userId: string, role: 'normal' | 'admin', accessToken: string) => {
-      set({ userId, role, accessToken, userStatus: role === 'admin' ? 'admin' : 'normal' });
+    login: (userId: string, role: 'normal' | 'admin') => {
+      set({ userId, role, userStatus: role === 'admin' ? 'admin' : 'normal' });
       localStorage.setItem('userId', userId);
       localStorage.setItem('role', role);
-      localStorage.setItem('accessToken', accessToken);
-      console.log(localStorage.getItem('accessToken'));
     },
 
     logout: () => {


### PR DESCRIPTION
## 이슈 번호

- close #121 

## 작업 사항
![Screenshot 2024-11-26 at 14 54 28](https://github.com/user-attachments/assets/f667cb7e-050a-470c-857a-b5d2c6c5f79a)
- [x] url 받아서 이미지 전송 시키기
  - 이전에 push 안됐던 거 적용 (git local 오류)
- [x] 토큰 가져오는 방식 다시 수정하기
- [x] 리스트 status가 onGoing, finished 만 가져오기
- [x] 리스트 개수 -> 페이지네이션
- [x] 챌린지 리스트 - 리스트 비었을 때 만들기

## 기타

다음 작업 사항
- 로컬 스토리지 문제 해결하기
- 챌린지 리스트 sort API 연결
- cancel, abort API 연결
  - id와 매치해서 본인 챌린지에 토글 뜨게 만들기
  - 챌린지status patch - status만 보내도 됨.
  - token 넘겨주어야 함.