### PR TITLE
Cancel 토글 API 연결

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,9 +1,13 @@
 import axios, { type InternalAxiosRequestConfig } from 'axios';
+import https from 'https';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 const instance = axios.create({
   baseURL: `${BASE_URL}`,
-  timeout: 10000
+  timeout: 10000,
+  httpsAgent: new https.Agent({
+    rejectUnauthorized: false
+  })
 });
 
 instance.interceptors.request.use(

--- a/src/api/challengeService.ts
+++ b/src/api/challengeService.ts
@@ -1,5 +1,5 @@
 import type { ChallengeParticipateStatusProps } from '@/interfaces/cardInterface';
-import { getRequest, postRequest } from './api';
+import { getRequest, patchRequest, postRequest } from './api';
 
 export const fetchChallenge = async () => {
   try {
@@ -74,5 +74,15 @@ export const fetchChallengeRequest = async (data: object) => {
       errorMessage = '먼저 로그인해 주세요.';
     }
     alert(errorMessage);
+  }
+};
+
+export const fetchUpdateStatus = async (challengeId: string, newStatus: 'canceled' | 'aborted') => {
+  try {
+    const response = await patchRequest(`/challenges/${challengeId}/status`, { status: newStatus });
+    return response.data;
+  } catch (error) {
+    console.error('Failed to update challenge status:', error);
+    throw error;
   }
 };

--- a/src/api/challengeService.ts
+++ b/src/api/challengeService.ts
@@ -77,9 +77,12 @@ export const fetchChallengeRequest = async (data: object) => {
   }
 };
 
-export const fetchUpdateStatus = async (challengeId: string, newStatus: 'canceled' | 'aborted') => {
+export const fetchUpdateStatus = async (challengeId: string, newStatus: 'canceled' | 'aborted', reason: string) => {
   try {
-    const response = await patchRequest(`/challenges/${challengeId}/status`, { status: newStatus });
+    const response = await patchRequest(`/challenges/${challengeId}/status`, {
+      status: newStatus,
+      abortReason: reason
+    });
     return response.data;
   } catch (error) {
     console.error('Failed to update challenge status:', error);

--- a/src/components/Card/ChallengeCard.tsx
+++ b/src/components/Card/ChallengeCard.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 import clockIcon from '@/../public/assets/icon_deadline_clock_large.png';
 import kebabToggle from '@/../public/assets/icon_kebab_toggle.png';
+import { fetchUpdateStatus } from '@/api/challengeService';
 import ChipCard from '@/components/Chip/ChipCard';
 import ChipCategoryCard from '@/components/Chip/ChipCategory';
 import type { ChallengeCardProps } from '@/interfaces/cardInterface';
@@ -12,7 +13,9 @@ export default function ChallengeCard({ data, userId, role }: ChallengeCardProps
     return <div>로딩 중...</div>;
   }
 
-  const { id, title, deadline, status, mediaType, requestUserId } = data;
+  const { id, title, deadline, status, mediaType, requestUser } = data;
+
+  console.log(data);
   const formattedDeadline = new Date(deadline).toISOString().split('T')[0];
 
   const handleStatusChange = (id: string, newStatus: 'onGoing' | 'canceled') => {
@@ -29,8 +32,15 @@ export default function ChallengeCard({ data, userId, role }: ChallengeCardProps
     event.stopPropagation();
     setDropdownOpen(prev => !prev);
   };
-  const handleCancelClick = () => {
+
+  const handleCancelClick = async () => {
     setDropdownOpen(false);
+
+    try {
+      await fetchUpdateStatus(id, 'canceled');
+    } catch (error) {
+      console.error('Failed to update challenge status:', error);
+    }
   };
 
   // NOTE API 연결해서 챌린지 상태 수정하기 abort
@@ -42,7 +52,7 @@ export default function ChallengeCard({ data, userId, role }: ChallengeCardProps
             <div>
               <ChipCard type={status} />
             </div>
-            {role === 'admin' || userId === requestUserId ? (
+            {role === 'admin' || userId === requestUser.id ? (
               <div className="relative">
                 <Image src={kebabToggle} alt="More Options" onClick={handledropdownClick} className="cursor-pointer" />
                 <div className="absolute right-[1rem] top-[2.5rem]">

--- a/src/components/Card/MonthlyChallengeCard.tsx
+++ b/src/components/Card/MonthlyChallengeCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import crownIcon from '@/../public/assets/icon_crown.png';
 import clockIcon from '@/../public/assets/icon_deadline_clock_large.png';
@@ -7,28 +8,61 @@ import ChipCard from '@/components/Chip/ChipCard';
 import ChipCategoryCard from '@/components/Chip/ChipCategory';
 import type { MonthlyChallengeCardProps } from '@/interfaces/cardInterface';
 import CancelDropdown from '../Dropdown/CancelDropdown';
+import ConfirmModal from '../Modal/ConfirmModal';
 
 export default function MonthlyChallengeCard({ data, role }: MonthlyChallengeCardProps) {
   if (!data) {
     return <div>로딩 중...</div>;
   }
 
+  const router = useRouter();
+
   const { title, mediaType, status, deadline } = data;
   const formattedDeadline = new Date(deadline).toISOString().split('T')[0];
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [abortReason, setAbortReason] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handledropdownClick = (event: React.MouseEvent) => {
     event.stopPropagation();
     setDropdownOpen(prev => !prev);
   };
-  const handleCancelClick = () => {
-    setDropdownOpen(false);
+  const handleModalCancel = () => {
+    setIsModalOpen(false);
   };
 
-  // NOTE API 연결해서 챌린지 상태 수정하기 cancel
+  const handleCancelClick = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+    setDropdownOpen(false);
+    setIsModalOpen(true);
+  };
+
+  // NOTE API 연결해서 챌린지 상태 수정하기 abort
+  const handleDeleteWork = async () => {
+    try {
+      const newStatus = 'aborted';
+      const reason = abortReason;
+      // await fetchUpdateStatus(id, newStatus, reason);
+      setIsModalOpen(false);
+      router.refresh();
+    } catch (error) {
+      console.error('Failed to update challenge status:', error);
+    }
+  };
+
+  const handleCardClick = (event: React.MouseEvent) => {
+    if (isModalOpen) {
+      event.stopPropagation();
+      return;
+    }
+  };
+
   return (
-    <div className="w-[38.4rem] gap-[1rem] rounded-[1.2rem] border-[0.2rem] border-solid border-primary-beige bg-primary-white">
+    <div
+      className="w-[38.4rem] gap-[1rem] rounded-[1.2rem] border-[0.2rem] border-solid border-primary-beige bg-primary-white"
+      onClick={handleCardClick}
+    >
       <div>
         <div className="p-[2.4rem]">
           <div className="flex justify-between items-center">
@@ -47,7 +81,7 @@ export default function MonthlyChallengeCard({ data, role }: MonthlyChallengeCar
               </div>
             ) : null}
           </div>
-
+          {isModalOpen && <ConfirmModal onCancel={handleModalCancel} onDelete={handleDeleteWork} />}
           <h2 className="text-[2rem] leading-[2.39rem] mt-[1.2rem] mb-[1.4rem] font-semibold text-left text-gray-700">{title}</h2>
 
           <div>

--- a/src/components/ClientWrapper/ChallengeListClient.tsx
+++ b/src/components/ClientWrapper/ChallengeListClient.tsx
@@ -15,7 +15,7 @@ import Pagination from '../Pagination/Pagination';
 
 export default function ChallengeListClient({ adminchallengeData, challengeData, rankerData }: ChallengeListClientProps) {
   const router = useRouter();
-  const { userId, role, category, setCategory, keyword, setKeyword } = useStore();
+  const { id, role, category, setCategory, keyword, setKeyword } = useStore();
 
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 4;
@@ -95,7 +95,7 @@ export default function ChallengeListClient({ adminchallengeData, challengeData,
           <div className="flex justify-between grid grid-cols-2 grid-rows-2 gap-[2.4rem]">
             {mediumItems.map((data, index) => (
               <div key={index} onClick={() => handleChallengeClick(data.id)} className="cursor-pointer">
-                <ChallengeCard data={data} userId={userId} role={role} />
+                <ChallengeCard data={data} userId={id} role={role} />
               </div>
             ))}
           </div>

--- a/src/components/ClientWrapper/SignInClient.tsx
+++ b/src/components/ClientWrapper/SignInClient.tsx
@@ -25,7 +25,8 @@ export default function SignIn() {
       localStorage.setItem('accessToken', res.accessToken);
       router.push('/challengeList');
       const { login } = useStore.getState();
-      login(res.userId, res.role);
+      login(res.id, res.role);
+      console.log(res.id);
     } catch (err: any) {
       let errorMessage = 'An unexpected error occurred. Please try again.';
       if (err?.response?.data?.field === '이메일 또는 비밀번호가 잘못되었습니다.') {

--- a/src/interfaces/cardInterface.ts
+++ b/src/interfaces/cardInterface.ts
@@ -57,10 +57,15 @@ export interface ChallengeData {
   mediaType: 'recipeWeb' | 'socialMedia' | 'youtube' | 'blog';
   status: 'onGoing' | 'finished' | 'canceled';
   deadline: string;
-  requestUserId: string;
+  requestUser: RequestUser;
   totalLikes: number;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface RequestUser {
+  id: string;
+  name: string;
 }
 
 export interface MonthlyChallengeCardProps {

--- a/src/interfaces/cardInterface.ts
+++ b/src/interfaces/cardInterface.ts
@@ -55,7 +55,7 @@ export interface ChallengeData {
   id: string;
   title: string;
   mediaType: 'recipeWeb' | 'socialMedia' | 'youtube' | 'blog';
-  status: 'onGoing' | 'finished' | 'canceled';
+  status: 'onGoing' | 'finished';
   deadline: string;
   requestUser: RequestUser;
   totalLikes: number;

--- a/src/interfaces/dropdownInterface.ts
+++ b/src/interfaces/dropdownInterface.ts
@@ -18,6 +18,8 @@ export interface DropdownItem {
 }
 
 export interface CancelDropdownProps {
-  onCancel: () => void;
+  onCancel: (event: React.MouseEvent) => void | Promise<void>;
   children: ReactNode;
+  abortReason?: string;
+  setAbortReason?: (reason: string) => void;
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -18,10 +18,10 @@ interface StoreState {
   setIsFilterApplied: (isApplied: boolean) => void;
   toggleDropdown: (isOpen: boolean) => void;
   userStatus: 'loggedOut' | 'normal' | 'admin';
-  userId: string | null;
+  id: string | null;
   role: 'normal' | 'admin' | null;
   isLoading: boolean;
-  login: (userId: string, role: 'normal' | 'admin') => void;
+  login: (id: string, role: 'normal' | 'admin') => void;
   logout: () => void;
   setUserStatus: (status: 'loggedOut' | 'normal' | 'admin') => void;
   setLoading: (isLoading: boolean) => void;
@@ -48,19 +48,19 @@ const useStore = create<StoreState>(set => ({
   toggleDropdown: isOpen => set({ isDropdownOpen: isOpen }),
 
   userStatus: 'loggedOut',
-  userId: null,
+  id: null,
   role: null,
 
-  login: (userId, role) => {
-    set({ userId, role, userStatus: role === 'admin' ? 'admin' : 'normal' });
+  login: (id, role) => {
+    set({ id, role, userStatus: role === 'admin' ? 'admin' : 'normal' });
     if (typeof window !== 'undefined') {
-      localStorage.setItem('userId', userId);
+      localStorage.setItem('userId', id);
       localStorage.setItem('role', role);
     }
   },
 
   logout: () => {
-    set({ userId: null, role: null, userStatus: 'loggedOut' });
+    set({ id: null, role: null, userStatus: 'loggedOut' });
     if (typeof window !== 'undefined') {
       localStorage.removeItem('userId');
       localStorage.removeItem('role');


### PR DESCRIPTION
## 이슈 번호

- close #130 

## 작업 사항
- [x] id와 매치해서 본인 챌린지에 토글 뜨게 만들기 (id를 못불러오는 듯 함)
- [x] cancel API 연결
  - 모달 창 연결
  - 어드민챌린지는 백엔드 API 완성되어야 할 수 있음.
  - 모달 yes 누른 후 refresh가 잘 안된다 ..?

## 기타
- 챌린지 리스트 sort API 연결
  - filterbar css 날아간 문제 해결
- modal에 abort reason 쓰는 input 집어넣기
  - 그러면 API 바로 작동 가능