### PR TITLE
챌린지 리스트 sort API 연결

### DIFF
--- a/src/api/challengeService.ts
+++ b/src/api/challengeService.ts
@@ -1,9 +1,9 @@
 import type { ChallengeParticipateStatusProps } from '@/interfaces/cardInterface';
 import { getRequest, patchRequest, postRequest } from './api';
 
-export const fetchChallenge = async () => {
+export const fetchChallenge = async (queryParams: string = '') => {
   try {
-    const response = await getRequest('/challenges');
+    const response = await getRequest(`/challenges${queryParams}`);
     return response.data;
   } catch (error) {
     throw new Error('Failed to get challenge');

--- a/src/components/Card/ChallengeCard.tsx
+++ b/src/components/Card/ChallengeCard.tsx
@@ -69,7 +69,7 @@ export default function ChallengeCard({ data, userId, role }: ChallengeCardProps
               <ChipCard type={status} />
             </div>
             {role === 'admin' || userId === requestUser.id ? (
-              <div className="relative">
+              <div className="relative z-10">
                 <Image src={kebabToggle} alt="More Options" onClick={handledropdownClick} className="cursor-pointer" />
                 <div className="absolute right-[1rem] top-[2.5rem]" onClick={e => e.stopPropagation()}>
                   {dropdownOpen && (

--- a/src/components/ClientWrapper/ChallengeListClient.tsx
+++ b/src/components/ClientWrapper/ChallengeListClient.tsx
@@ -38,7 +38,8 @@ export default function ChallengeListClient({ adminchallengeData, challengeData,
     if (isFilterApplied) {
       const fetchFilteredData = async () => {
         try {
-          const filteredData = await fetchChallenge(`?orderBy=${orderBy}&mediaType=${mediaType.join(',')}&status=${status}`);
+          const queryParams = createQueryParams(orderBy, mediaType, status);
+          const filteredData = await fetchChallenge(queryParams);
           setMedium(filteredData.list);
         } catch (error) {
           console.error('Error fetching filtered challenges:', error);
@@ -48,6 +49,14 @@ export default function ChallengeListClient({ adminchallengeData, challengeData,
       fetchFilteredData();
     }
   }, [isFilterApplied, orderBy, mediaType, status]);
+
+  const createQueryParams = (orderBy: string, mediaType: string[], status: string): string => {
+    const params: string[] = [];
+    if (orderBy) params.push(`orderBy=${orderBy}`);
+    if (status) params.push(`status=${status}`);
+    mediaType.forEach(type => params.push(`mediaType=${type}`));
+    return `?${params.join('&')}`;
+  };
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -69,6 +78,11 @@ export default function ChallengeListClient({ adminchallengeData, challengeData,
     const count = (orderBy ? 1 : 0) + mediaType.length + (status ? 1 : 0);
     setSelectedCount(count);
     setIsFilterApplied(count > 0);
+
+    if (!orderBy && mediaType.length === 0 && !status) {
+      window.location.reload();
+      return;
+    }
   };
 
   return (

--- a/src/components/ClientWrapper/ChallengeListClient.tsx
+++ b/src/components/ClientWrapper/ChallengeListClient.tsx
@@ -82,13 +82,17 @@ export default function ChallengeListClient({ adminchallengeData, challengeData,
               onCategoryChange={setCategory}
               onFilterApply={handleFilterChange}
             />
-            <button
-              onClick={handleRequestClick}
-              className="bg-primary-beige text-primary-white border rounded-[1.95rem] flex items-center gap-[0.8rem]"
-            >
-              <span className="text-[1.6rem] ml-[1.6rem]">Request a Challenge</span>
-              <Image src={plus} alt="plus" className="mr-[1.6rem]" />
-            </button>
+            {role === 'normal' ? (
+              <button
+                onClick={handleRequestClick}
+                className="bg-primary-beige text-primary-white border rounded-[1.95rem] flex items-center gap-[0.8rem]"
+              >
+                <span className="text-[1.6rem] ml-[1.6rem]">Request a Challenge</span>
+                <Image src={plus} alt="plus" className="mr-[1.6rem]" />
+              </button>
+            ) : (
+              ''
+            )}
           </div>
         </div>
         {mediumItems.length > 0 ? (

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import activeCheckBox from '@/../public/assets/btn_active_checkbox.png';
 import inActiveCheckBox from '@/../public/assets/btn_inactive_checkbox.png';
@@ -18,20 +17,7 @@ const dropdownWidths = {
 };
 
 export default function Dropdown({ isOpen, items, type, onApply, onClose }: DropdownProps) {
-  const router = useRouter();
-  const {
-    selectedView,
-    selectedMedia,
-    selectedStatus,
-    setSelectedView,
-    setSelectedMedia,
-    setSelectedStatus,
-    category,
-    setCategory,
-    toggleDropdown,
-    isFilterApplied,
-    setIsFilterApplied
-  } = useStore();
+  const { selectedView, selectedMedia, selectedStatus, setSelectedView, setSelectedMedia, setSelectedStatus } = useStore();
 
   const dropdownType = dropdownWidths[type] || '';
 
@@ -44,24 +30,10 @@ export default function Dropdown({ isOpen, items, type, onApply, onClose }: Drop
         updatedMedia = [...(selectedMedia || []), value];
       }
       setSelectedMedia(updatedMedia);
-
-      const queryString = new URLSearchParams(window.location.search);
-      queryString.delete('mediaType');
-      updatedMedia.forEach(item => queryString.append('mediaType', item));
-      const newUrl = `${window.location.pathname}?${queryString.toString()}`;
-      window.history.replaceState(null, '', newUrl);
     } else if (category === 'orderBy') {
       setSelectedView(value);
-      const queryString = new URLSearchParams(window.location.search);
-      queryString.set('orderBy', value);
-      const newUrl = `${window.location.pathname}?${queryString.toString()}`;
-      window.history.replaceState(null, '', newUrl);
     } else if (category === 'status') {
       setSelectedStatus(value);
-      const queryString = new URLSearchParams(window.location.search);
-      queryString.set('status', value);
-      const newUrl = `${window.location.pathname}?${queryString.toString()}`;
-      window.history.replaceState(null, '', newUrl);
     }
   };
 
@@ -69,22 +41,16 @@ export default function Dropdown({ isOpen, items, type, onApply, onClose }: Drop
     setSelectedView('');
     setSelectedMedia([]);
     setSelectedStatus('');
-
-    const queryString = new URLSearchParams(window.location.search);
-    queryString.delete('orderBy');
-    queryString.delete('mediaType');
-    queryString.delete('status');
-    const newUrl = `${window.location.pathname}?${queryString.toString()}`;
-    window.history.replaceState(null, '', newUrl);
   };
 
   const handleApply = () => {
     const mediaArray = selectedMedia || [];
     const selectedCount = (selectedView ? 1 : 0) + mediaArray.length + (selectedStatus ? 1 : 0);
+
     if (selectedCount > 0) {
       onApply(selectedView || '', mediaArray, selectedStatus || '');
     } else {
-      location.reload();
+      onApply('', [], '');
     }
 
     onClose();

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -36,33 +36,46 @@ export default function Dropdown({ isOpen, items, type, onApply, onClose }: Drop
   const dropdownType = dropdownWidths[type] || '';
 
   const handleSelect = (value: string, category?: CategoryType) => {
-    if (category === 'view') {
-      setSelectedView(value);
-    } else if (category === 'media') {
+    if (category === 'mediaType') {
+      let updatedMedia;
       if (selectedMedia?.includes(value)) {
-        setSelectedMedia(selectedMedia.filter(item => item !== value));
+        updatedMedia = selectedMedia.filter(item => item !== value);
       } else {
-        setSelectedMedia([...selectedMedia, value]);
+        updatedMedia = [...(selectedMedia || []), value];
       }
+      setSelectedMedia(updatedMedia);
+
+      const queryString = new URLSearchParams(window.location.search);
+      queryString.delete('mediaType');
+      updatedMedia.forEach(item => queryString.append('mediaType', item));
+      const newUrl = `${window.location.pathname}?${queryString.toString()}`;
+      window.history.replaceState(null, '', newUrl);
+    } else if (category === 'orderBy') {
+      setSelectedView(value);
+      const queryString = new URLSearchParams(window.location.search);
+      queryString.set('orderBy', value);
+      const newUrl = `${window.location.pathname}?${queryString.toString()}`;
+      window.history.replaceState(null, '', newUrl);
     } else if (category === 'status') {
       setSelectedStatus(value);
+      const queryString = new URLSearchParams(window.location.search);
+      queryString.set('status', value);
+      const newUrl = `${window.location.pathname}?${queryString.toString()}`;
+      window.history.replaceState(null, '', newUrl);
     }
-
-    const queryString = new URLSearchParams(window.location.search);
-    queryString.set(category || 'category', value);
-    router.push(`?${queryString.toString()}`);
-
-    toggleDropdown(false);
   };
 
   const handleReset = () => {
     setSelectedView('');
+    setSelectedMedia([]);
     setSelectedStatus('');
 
     const queryString = new URLSearchParams(window.location.search);
-    queryString.delete('view');
+    queryString.delete('orderBy');
+    queryString.delete('mediaType');
     queryString.delete('status');
-    router.push(`?${queryString.toString()}`);
+    const newUrl = `${window.location.pathname}?${queryString.toString()}`;
+    window.history.replaceState(null, '', newUrl);
   };
 
   const handleApply = () => {
@@ -70,14 +83,17 @@ export default function Dropdown({ isOpen, items, type, onApply, onClose }: Drop
     const selectedCount = (selectedView ? 1 : 0) + mediaArray.length + (selectedStatus ? 1 : 0);
     if (selectedCount > 0) {
       onApply(selectedView || '', mediaArray, selectedStatus || '');
+    } else {
+      location.reload();
     }
+
     onClose();
   };
 
   const renderItems = () => {
     if (type === 'challenge') {
       const flattenedItems = (items as ChallengeOption[])[0];
-      const { view, media, status } = flattenedItems;
+      const { orderBy, mediaType, status } = flattenedItems;
 
       return (
         <div className="w-full border-2 border-gray-200 rounded-[0.8rem]">
@@ -85,15 +101,15 @@ export default function Dropdown({ isOpen, items, type, onApply, onClose }: Drop
             <p className="font-semibold text-[1.6rem] leading-[1.909rem] text-gray-700">Sort</p>
             <Image src={close} alt="닫기" onClick={() => onClose()} />
           </div>
-          <div key="view-section" className="py-[1.2rem] px-[1.6rem]">
+          <div key="view-section" className="pt-[1.2rem] pb-[1.4rem] px-[1.6rem]">
             <div className="font-semibold text-[1.4rem] leading-[1.671rem] text-gray-700 mt-[1.1rem] mb-[1.2rem]">
               View Option Type
             </div>
-            {view.map(item => (
-              <div key={`view-${item.value}`} className="flex mb-[1.2rem] items-center gap-[0.4rem]">
+            {orderBy.map(item => (
+              <div key={`view-${item.value}`} className="flex mb-[0.4rem] items-center gap-[0.4rem]">
                 <Image src={selectedView === item.value ? activeRadio : inactiveRadio} alt="radio" />
                 <p
-                  onClick={() => handleSelect(item.value, 'view')}
+                  onClick={() => handleSelect(item.value, 'orderBy')}
                   className="w-full font-normal text-[1.4rem] leading-[1.671rem] text-gray-700 items-center flex cursor-pointer"
                 >
                   {item.label}
@@ -101,16 +117,14 @@ export default function Dropdown({ isOpen, items, type, onApply, onClose }: Drop
               </div>
             ))}
           </div>
-          <div className="border border-gray-200 w-full mt-[1.2rem] mb-[1.2rem]" />
-          <div key="media-section" className="w-full py-[1.2rem] px-[1.6rem]">
-            <div className="font-semibold text-[1.4rem] leading-[1.671rem] text-gray-700 mt-[1.1rem] mb-[1.2rem]">
-              Recipe Media Type
-            </div>
-            {media.map(item => (
-              <div key={`media-${item.value}`} className="flex items-center gap-[0.4rem] mb-[1.2rem]">
+          <div className="border border-gray-200 w-full" />
+          <div key="media-section" className="w-full pt-[1.2rem] pb-[2.4rem] px-[1.6rem]">
+            <div className="font-semibold text-[1.4rem] leading-[1.671rem] text-gray-700 mb-[1.2rem]">Recipe Media Type</div>
+            {mediaType.map(item => (
+              <div key={`media-${item.value}`} className="flex items-center gap-[0.4rem] mb-[0.4rem]">
                 <Image src={selectedMedia?.includes(item.value) ? activeCheckBox : inActiveCheckBox} alt="checkbox" />
                 <p
-                  onClick={() => handleSelect(item.value, 'media')}
+                  onClick={() => handleSelect(item.value, 'mediaType')}
                   className="w-full font-normal text-[1.4rem] leading-[1.671rem] text-gray-700 items-center flex cursor-pointer"
                 >
                   {item.label}
@@ -118,11 +132,11 @@ export default function Dropdown({ isOpen, items, type, onApply, onClose }: Drop
               </div>
             ))}
           </div>
-          <div className="border border-gray-200 w-full mt-[1.2rem] mb-[1.2rem]" />
+          <div className="border border-gray-200 w-full" />
           <div key="status-section" className="w-full py-[1.2rem] px-[1.6rem]">
-            <div className="font-semibold text-[1.4rem] leading-[1.671rem] text-gray-700 mt-[1.1rem] mb-[1.2rem]">Status</div>
+            <div className="font-semibold text-[1.4rem] leading-[1.671rem] text-gray-700 mb-[1.2rem]">Status</div>
             {status.map(item => (
-              <div key={`status-${item.value}`} className="flex mb-[1.2rem] items-center gap-[0.4rem]">
+              <div key={`status-${item.value}`} className="flex mb-[0.4rem] items-center gap-[0.4rem]">
                 <Image src={selectedStatus === item.value ? activeRadio : inactiveRadio} alt="radio" />
                 <p
                   onClick={() => handleSelect(item.value, 'status')}
@@ -133,7 +147,7 @@ export default function Dropdown({ isOpen, items, type, onApply, onClose }: Drop
               </div>
             ))}
           </div>
-          <div className="flex justify-between p-[1.6rem]">
+          <div className="flex justify-between p-[1.6rem] gap-[0.8rem]">
             <button
               onClick={handleReset}
               className="w-[13.4rem] h-[4rem] py-[0.2rem] px-[1.6rem] border border-gray-200 font-semibold text-[1.6rem] leading-[1.909rem] text-gray-700 rounded-[0.8rem]"

--- a/src/components/FilterBar/FilterBar.tsx
+++ b/src/components/FilterBar/FilterBar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import filter from '@/../public/assets/ic_filter.png';
 import activeFilter from '@/../public/assets/icon_filter_active.png';
@@ -70,7 +69,6 @@ const optionsByType: Record<string, Option[] | ChallengeOption[]> = {
 };
 
 export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
-  const router = useRouter();
   const { keyword, category, setKeyword, setCategory, toggleDropdown } = useStore();
 
   const filterBarType = filterBarWidths[type] || '';
@@ -126,19 +124,11 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
     if (e.key === 'Enter') {
       const currentKeyword = e.currentTarget.value;
       setKeyword(currentKeyword);
-      const queryString = new URLSearchParams({ keyword: currentKeyword }).toString();
-
-      router.push(`?${queryString}`);
     }
   };
 
   useEffect(() => {
     setKeyword('');
-
-    const query = new URLSearchParams(window.location.search);
-    query.delete('keyword');
-    query.delete('category');
-    router.push(`${window.location.pathname}?${query.toString()}`);
   }, []);
 
   const handleApply = (orderBy: string, mediaType: string[], status: string) => {
@@ -146,13 +136,8 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
     setSelectedCount(count);
     setIsFilterApplied(count > 0);
 
-    const query = new URLSearchParams();
-    if (orderBy) query.append('orderBy', orderBy);
-    if (mediaType.length > 0) query.append('mediaType', mediaType.join(','));
-    if (status) query.append('status', status);
-
-    router.push(`${window.location.pathname}?${query.toString()}`);
-    setIsDropdownOpen(false);
+    onFilterApply(orderBy, mediaType, status);
+    toggleDropdown(false);
   };
 
   return (

--- a/src/components/FilterBar/FilterBar.tsx
+++ b/src/components/FilterBar/FilterBar.tsx
@@ -40,21 +40,21 @@ const optionsByType: Record<string, Option[] | ChallengeOption[]> = {
   ],
   challenge: [
     {
-      view: [
+      orderBy: [
         { label: 'Earliest First', value: 'earliestFirst' },
         { label: 'Latest First', value: 'latestFirst' },
         { label: 'Deadline Earliest', value: 'deadlineEarliest' },
         { label: 'Deadline Latest', value: 'deadlineLatest' }
       ],
-      media: [
+      mediaType: [
         { label: 'Youtube', value: 'youtube' },
         { label: 'Blog', value: 'blog' },
-        { label: 'Recipe Web', value: 'recipe web' },
-        { label: 'Social Media', value: 'social media' }
+        { label: 'Recipe Web', value: 'recipeWeb' },
+        { label: 'Social Media', value: 'socialMedia' }
       ],
       status: [
-        { label: 'On going', value: 'ongoing' },
-        { label: 'Closed', value: 'closed' }
+        { label: 'On going', value: 'onGoing' },
+        { label: 'Closed', value: 'finished' }
       ]
     }
   ],
@@ -78,15 +78,14 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
   const searchBarType = searchBarWidths[type] || '';
   const options = optionsByType[type] || [];
 
+  const [isFilterApplied, setIsFilterApplied] = useState(false);
+  const [selectedCount, setSelectedCount] = useState<number>(0);
   const [selectedSort, setSelectedSort] = useState<string | null>(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const [selectedView, setSelectedView] = useState<string>('');
   const [selectedMedia, setSelectedMedia] = useState<string[]>([]);
   const [selectedStatus, setSelectedStatus] = useState<string>('');
-
-  const [isFilterApplied, setIsFilterApplied] = useState(false);
-  const [selectedCount, setSelectedCount] = useState<number>(0);
 
   const handleToggleDropdown = () => {
     setIsDropdownOpen(prev => !prev);
@@ -108,10 +107,10 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
     }
   };
 
-  const handleSelect = (value: string, category?: 'view' | 'media' | 'status') => {
-    if (category === 'view') {
+  const handleSelect = (value: string, category?: 'orderBy' | 'mediaType' | 'status') => {
+    if (category === 'orderBy') {
       setSelectedView(value);
-    } else if (category === 'media') {
+    } else if (category === 'mediaType') {
       if (selectedMedia?.includes(value)) {
         setSelectedMedia(selectedMedia.filter(item => item !== value));
       } else {
@@ -142,11 +141,18 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
     router.push(`${window.location.pathname}?${query.toString()}`);
   }, []);
 
-  const handleApply = (view: string, media: string[], status: string) => {
-    const count = (view ? 1 : 0) + media.length + (status ? 1 : 0);
+  const handleApply = (orderBy: string, mediaType: string[], status: string) => {
+    const count = (orderBy ? 1 : 0) + mediaType.length + (status ? 1 : 0);
     setSelectedCount(count);
     setIsFilterApplied(count > 0);
-    handleToggleDropdown();
+
+    const query = new URLSearchParams();
+    if (orderBy) query.append('orderBy', orderBy);
+    if (mediaType.length > 0) query.append('mediaType', mediaType.join(','));
+    if (status) query.append('status', status);
+
+    router.push(`${window.location.pathname}?${query.toString()}`);
+    setIsDropdownOpen(false);
   };
 
   return (
@@ -159,7 +165,7 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
         >
           <p
             className={`font-normal text-[1.6rem] leading-[1.909rem]
-          ${isFilterApplied ? 'text-[#ffffff]' : 'text-gray-400'}`}
+          ${isFilterApplied ? 'text-primary-white' : 'text-gray-400'}`}
           >
             {getSelectedSortLabel()}
           </p>

--- a/src/components/FilterBar/FilterBar.tsx
+++ b/src/components/FilterBar/FilterBar.tsx
@@ -169,7 +169,7 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
           />
         </div>
       </div>
-      <div className="">
+      <div>
         {isDropdownOpen && (
           <Dropdown
             isOpen={isDropdownOpen}

--- a/src/components/FilterBar/FilterBar.tsx
+++ b/src/components/FilterBar/FilterBar.tsx
@@ -150,7 +150,7 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
   };
 
   return (
-    <div>
+    <div className="z-20">
       <div className={`h-[4rem] justify-between items-center flex ${filterBarType}`}>
         <div
           className={`flex justify-between items-center h-full rounded-[0.8rem] border border-gray-200 px-[1.2rem] py-[0.8rem] gap-[1rem] ${sortBarType}
@@ -178,7 +178,7 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
           />
         </div>
       </div>
-      <div className="z-9999">
+      <div className="">
         {isDropdownOpen && (
           <Dropdown
             isOpen={isDropdownOpen}

--- a/src/interfaces/cardInterface.ts
+++ b/src/interfaces/cardInterface.ts
@@ -77,7 +77,7 @@ export interface MonthlyChallengeData {
   id: string;
   title: string;
   mediaType: 'youtube' | 'blog' | 'socialMedia' | 'recipeWeb';
-  status: 'onGoing' | 'finished'; // NOTE | 'aborted' 아마 필요 없겠지만, 참고.
+  status: 'onGoing' | 'finished';
   deadline: string;
 }
 

--- a/src/interfaces/dropdownInterface.ts
+++ b/src/interfaces/dropdownInterface.ts
@@ -10,7 +10,7 @@ export interface DropdownProps {
   onClose: () => void;
 }
 
-export type CategoryType = 'view' | 'media' | 'status';
+export type CategoryType = 'orderBy' | 'mediaType' | 'status';
 
 export type OnSelectFunction = (value: string, category?: CategoryType) => void;
 

--- a/src/interfaces/filterBarInterface.ts
+++ b/src/interfaces/filterBarInterface.ts
@@ -11,7 +11,7 @@ export interface Option {
 }
 
 export interface ChallengeOption {
-  view: Option[];
-  media: Option[];
+  orderBy: Option[];
+  mediaType: Option[];
   status: Option[];
 }

--- a/src/interfaces/filterBarInterface.ts
+++ b/src/interfaces/filterBarInterface.ts
@@ -2,7 +2,7 @@ export interface FilterBarProps {
   type: 'recipe' | 'admin' | 'challenge';
   onKeywordChange: (value: string) => void;
   onCategoryChange: (value: string) => void;
-  onFilterApply: () => void;
+  onFilterApply: (orderBy: string, mediaType: string[], status: string) => void;
 }
 
 export interface Option {


### PR DESCRIPTION
## 이슈 번호

- close #138 

## 작업 사항
- [x] 챌린지 리스트 sort API 연결
  - filterbar css 날아간 문제 해결
  - css 전체 수정
  - reset, apply 구현
  - 미디어타입 취소 안되는거 구현
  - 미디어타입 중복 전송 안되는거 구현
- [x] challenge list 페이지에서 챌린지 요청 버튼 어드민 로그인 때 없애기


## 기타
- keyword 검색 API 연동 제대로 못함.
- modal에 abort reason 쓰는 input 집어넣기
  - 그러면 API 바로 작동 가능
- 어드민챌린지는 백엔드 API 완성되어야 할 수 있음.
  - 새로운 타입 지정 ?
- 현재 프론트에서 onGoing, finished로 걸러주고 있는데, 리스트 받아오는데 문제가 생겨서 백엔드 측에서 만들어주면 아래와 같이 수정.
  - 챌린지 리스트 페이지 / 어드민 관리 페이지 두개로 API 나눠서 하기