### PR TITLE
챌린지 API 연결 수정 및 Abort 모달 수정

### DIFF
--- a/src/api/challengeService.ts
+++ b/src/api/challengeService.ts
@@ -10,16 +10,6 @@ export const fetchChallenge = async (queryParams: string = '') => {
   }
 };
 
-export const getFilteredChallenges = async () => {
-  try {
-    const { list, totalCount } = await fetchChallenge();
-    const filteredList = list.filter((list: { status: string }) => ['onGoing', 'finished'].includes(list.status));
-    return { list: filteredList, totalCount };
-  } catch (error) {
-    throw new Error('Failed to get challenge');
-  }
-};
-
 export const fetchRanker = async () => {
   try {
     const response = await getRequest('http://localhost:3000/rankerMockData.json');
@@ -30,10 +20,9 @@ export const fetchRanker = async () => {
   }
 };
 
-export const fetchAdminChallenge = async () => {
+export const fetchAdminChallenge = async (queryParams: string = '') => {
   try {
-    const response = await getRequest('http://localhost:3000/adminchallengeMockData.json');
-    // const response = await getRequest('https://2-docthru-team1-n10tvnaef-team1-hancook.vercel.app/adminchallengeMockData.json');
+    const response = await getRequest(`/challenges/monthly${queryParams}`);
     return response.data;
   } catch (error) {
     throw new Error('Failed to get admin challenge data');

--- a/src/app/challengeList/page.tsx
+++ b/src/app/challengeList/page.tsx
@@ -1,4 +1,4 @@
-import { fetchAdminChallenge, fetchChallenge, fetchRanker, getFilteredChallenges } from '@/api/challengeService';
+import { fetchAdminChallenge, fetchChallenge, fetchRanker } from '@/api/challengeService';
 import ChallengeListClient from '@/components/ClientWrapper/ChallengeListClient';
 
 export default async function ChallengeListPage() {
@@ -7,30 +7,6 @@ export default async function ChallengeListPage() {
   if (process.env.NODE_ENV === 'production') {
     return DUMMY;
   }
-
-  const adminchallengeData = [
-    {
-      id: '1',
-      title: 'Mastering Kimchi Making',
-      mediaType: 'youtube' as 'youtube',
-      status: 'onGoing' as 'onGoing',
-      deadline: '2024-12-10T23:59:59.000Z'
-    },
-    {
-      id: '2',
-      title: '5 Days of Korean Vegan Recipes',
-      mediaType: 'blog' as 'blog',
-      status: 'finished' as 'finished',
-      deadline: '2024-11-18T23:59:59.000Z'
-    },
-    {
-      id: '3',
-      title: 'Quick Korean BBQ Tips',
-      mediaType: 'socialMedia' as 'socialMedia',
-      status: 'onGoing' as 'onGoing',
-      deadline: '2024-11-28T23:59:59.000Z'
-    }
-  ];
 
   const rankerData = [
     {
@@ -56,8 +32,11 @@ export default async function ChallengeListPage() {
     }
   ];
 
-  // const adminchallengeData = await fetchAdminChallenge();
-  const { list, totalCount } = await getFilteredChallenges();
+  const currentMonth = new Date().toLocaleString('en-US', { month: 'long' });
+  const queryParams = `?monthly=${currentMonth}`;
+
+  const adminchallengeData = await fetchAdminChallenge(queryParams);
+  const { list, totalCount } = await fetchChallenge();
   // const rankerData = await fetchRanker();
 
   const Data = {

--- a/src/app/challengeList/page.tsx
+++ b/src/app/challengeList/page.tsx
@@ -33,9 +33,9 @@ export default async function ChallengeListPage() {
   ];
 
   const currentMonth = new Date().toLocaleString('en-US', { month: 'long' });
-  const queryParams = `?monthly=${currentMonth}`;
+  const monthParams = `?monthly=${currentMonth}`;
 
-  const adminchallengeData = await fetchAdminChallenge(queryParams);
+  const adminchallengeData = await fetchAdminChallenge(monthParams);
   const { list, totalCount } = await fetchChallenge();
   // const rankerData = await fetchRanker();
 

--- a/src/app/recipeList/page.tsx
+++ b/src/app/recipeList/page.tsx
@@ -1,3 +1,4 @@
+import { fetchAdminChallenge } from '@/api/challengeService';
 import RecipeListClient from '@/components/ClientWrapper/RecipeListClient';
 
 export default async function RecipePage() {
@@ -7,9 +8,22 @@ export default async function RecipePage() {
     return DUMMY;
   }
 
+  const currentMonth = new Date().toLocaleString('en-US', { month: 'long' });
+  const queryParams = `?monthly=${currentMonth}`;
+
+  const adminchallengeData = await fetchAdminChallenge(queryParams);
+
+  const Data = {
+    adminchallengeData
+  };
+
   return (
     <div>
-      <RecipeListClient />
+      {Object.values(Data).every(value => !!value) ? (
+        <RecipeListClient adminchallengeData={adminchallengeData} />
+      ) : (
+        <p>Loading...</p>
+      )}
     </div>
   );
 }

--- a/src/components/Card/ChallengeCard.tsx
+++ b/src/components/Card/ChallengeCard.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import clockIcon from '@/../public/assets/icon_deadline_clock_large.png';
 import kebabToggle from '@/../public/assets/icon_kebab_toggle.png';
@@ -14,7 +13,6 @@ export default function ChallengeCard({ data, userId, role }: ChallengeCardProps
   if (!data) {
     return <div>로딩 중...</div>;
   }
-  const router = useRouter();
 
   const { id, title, deadline, status, mediaType, requestUser } = data;
 
@@ -44,7 +42,7 @@ export default function ChallengeCard({ data, userId, role }: ChallengeCardProps
       const reason = role === 'admin' ? abortReason : '';
       await fetchUpdateStatus(id, newStatus, reason);
       setIsModalOpen(false);
-      router.refresh();
+      window.location.reload();
     } catch (error) {
       console.error('Failed to update challenge status:', error);
     }

--- a/src/components/Card/ChallengeCard.tsx
+++ b/src/components/Card/ChallengeCard.tsx
@@ -90,7 +90,15 @@ export default function ChallengeCard({ data, userId, role }: ChallengeCardProps
           </div>
         </div>
       </div>
-      {isModalOpen && <ConfirmModal onCancel={handleModalCancel} onDelete={handleDeleteWork} />}
+      {isModalOpen && (
+        <ConfirmModal
+          onCancel={handleModalCancel}
+          onDelete={handleDeleteWork}
+          role={role}
+          abortReason={abortReason}
+          setAbortReason={setAbortReason}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/Card/MonthlyChallengeCard.tsx
+++ b/src/components/Card/MonthlyChallengeCard.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import crownIcon from '@/../public/assets/icon_crown.png';
 import clockIcon from '@/../public/assets/icon_deadline_clock_large.png';
@@ -15,8 +14,6 @@ export default function MonthlyChallengeCard({ data, role }: MonthlyChallengeCar
   if (!data) {
     return <div>로딩 중...</div>;
   }
-
-  const router = useRouter();
 
   const { id, title, mediaType, status, deadline } = data;
   const formattedDeadline = new Date(deadline).toISOString().split('T')[0];
@@ -45,7 +42,7 @@ export default function MonthlyChallengeCard({ data, role }: MonthlyChallengeCar
       const reason = abortReason;
       await fetchUpdateStatus(id, newStatus, reason);
       setIsModalOpen(false);
-      router.refresh();
+      window.location.reload();
     } catch (error) {
       console.error('Failed to update challenge status:', error);
     }
@@ -73,9 +70,9 @@ export default function MonthlyChallengeCard({ data, role }: MonthlyChallengeCar
               </div>
             </div>
             {role === 'admin' ? (
-              <div className="relative">
+              <div className="relative z-10">
                 <Image src={kebabToggle} alt="More Options" onClick={handledropdownClick} className="cursor-pointer" />
-                <div className="absolute right-[1rem] top-[2.5rem]">
+                <div className="absolute right-[1rem] top-[2.5rem]" onClick={e => e.stopPropagation()}>
                   {dropdownOpen && <CancelDropdown onCancel={handleCancelClick}>Abort</CancelDropdown>}
                 </div>
               </div>

--- a/src/components/Card/MonthlyChallengeCard.tsx
+++ b/src/components/Card/MonthlyChallengeCard.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import crownIcon from '@/../public/assets/icon_crown.png';
 import clockIcon from '@/../public/assets/icon_deadline_clock_large.png';
 import kebabToggle from '@/../public/assets/icon_kebab_toggle.png';
+import { fetchUpdateStatus } from '@/api/challengeService';
 import ChipCard from '@/components/Chip/ChipCard';
 import ChipCategoryCard from '@/components/Chip/ChipCategory';
 import type { MonthlyChallengeCardProps } from '@/interfaces/cardInterface';
@@ -17,7 +18,7 @@ export default function MonthlyChallengeCard({ data, role }: MonthlyChallengeCar
 
   const router = useRouter();
 
-  const { title, mediaType, status, deadline } = data;
+  const { id, title, mediaType, status, deadline } = data;
   const formattedDeadline = new Date(deadline).toISOString().split('T')[0];
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -43,7 +44,7 @@ export default function MonthlyChallengeCard({ data, role }: MonthlyChallengeCar
     try {
       const newStatus = 'aborted';
       const reason = abortReason;
-      // await fetchUpdateStatus(id, newStatus, reason);
+      await fetchUpdateStatus(id, newStatus, reason);
       setIsModalOpen(false);
       router.refresh();
     } catch (error) {

--- a/src/components/Card/MonthlyChallengeCard.tsx
+++ b/src/components/Card/MonthlyChallengeCard.tsx
@@ -39,7 +39,6 @@ export default function MonthlyChallengeCard({ data, role }: MonthlyChallengeCar
     setIsModalOpen(true);
   };
 
-  // NOTE API 연결해서 챌린지 상태 수정하기 abort
   const handleDeleteWork = async () => {
     try {
       const newStatus = 'aborted';
@@ -82,7 +81,15 @@ export default function MonthlyChallengeCard({ data, role }: MonthlyChallengeCar
               </div>
             ) : null}
           </div>
-          {isModalOpen && <ConfirmModal onCancel={handleModalCancel} onDelete={handleDeleteWork} />}
+          {isModalOpen && (
+            <ConfirmModal
+              onCancel={handleModalCancel}
+              onDelete={handleDeleteWork}
+              role={role}
+              abortReason={abortReason}
+              setAbortReason={setAbortReason}
+            />
+          )}
           <h2 className="text-[2rem] leading-[2.39rem] mt-[1.2rem] mb-[1.4rem] font-semibold text-left text-gray-700">{title}</h2>
 
           <div>

--- a/src/components/ClientWrapper/ChallengeListClient.tsx
+++ b/src/components/ClientWrapper/ChallengeListClient.tsx
@@ -96,11 +96,7 @@ export default function ChallengeListClient({ adminchallengeData, challengeData,
           {adminchallengeData.length > 0 ? (
             <div className="flex gap-[2.55rem]">
               {adminchallengeData.map((data, index) => (
-                <div
-                  key={index}
-                  // onClick={() => handleChallengeClick(data.id)}
-                  // className="cursor-pointer"
-                >
+                <div key={index} onClick={() => handleChallengeClick(data.id)} className="cursor-pointer">
                   <MonthlyChallengeCard data={data} role={role} />
                 </div>
               ))}

--- a/src/components/ClientWrapper/RecipeListClient.tsx
+++ b/src/components/ClientWrapper/RecipeListClient.tsx
@@ -15,10 +15,14 @@ import MonthlyChallengeCard from '../Card/MonthlyChallengeCard';
 import RecipeFilterBar from '../FilterBar/RecipeFilterBar';
 import Pagination from '../Pagination/Pagination';
 
-export default function RecipeListClient() {
+interface AdminListClientProps {
+  adminchallengeData: AdminData[];
+}
+
+export default function RecipeListClient({ adminchallengeData }: AdminListClientProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { keyword, category, setKeyword, setCategory } = useStore();
+  const { role, keyword, category, setKeyword, setCategory } = useStore();
 
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 8;
@@ -45,8 +49,6 @@ export default function RecipeListClient() {
     }
   }, [currentPage, hasMore, isPlaceholderData, keyword, category]);
 
-  const [adminData, setAdminData] = useState<AdminData[]>();
-
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
   };
@@ -59,13 +61,9 @@ export default function RecipeListClient() {
     setCategory(category);
   };
 
-  useEffect(() => {
-    const getAdminChallengeData = async () => {
-      const data = await fetchAdminChallenge();
-      setAdminData(data);
-    };
-    getAdminChallengeData();
-  }, []);
+  const handleChallengeClick = (id: string) => {
+    router.push(`/challengeList/${id}`);
+  };
 
   if (isLoading) {
     return (
@@ -89,8 +87,11 @@ export default function RecipeListClient() {
         <div className="flex flex-col gap-[2.4rem] justify-center">
           <p className="font-semibold text-[2rem] leading-[2.387rem] text-gray-700">This Month's Challenge</p>
           <div className="flex justify-between">
-            {Array.isArray(adminData) &&
-              adminData.map(items => <MonthlyChallengeCard key={items.id} data={items} role="normal" />)}
+            {adminchallengeData.map((data, index) => (
+              <div key={index} onClick={() => handleChallengeClick(data.id)} className="cursor-pointer">
+                <MonthlyChallengeCard data={data} role={role} />
+              </div>
+            ))}
           </div>
         </div>
         <div className="flex flex-col gap-[1.6rem]">

--- a/src/components/Modal/ConfirmModal.tsx
+++ b/src/components/Modal/ConfirmModal.tsx
@@ -2,16 +2,26 @@ import Image from 'next/image';
 import check from '@/../public/assets/icon_confirm_modal_check.png';
 import type { ConfirmModalProps } from '@/interfaces/modalInterface';
 
-export default function ConfirmModal({ onCancel, onDelete }: ConfirmModalProps) {
+export default function ConfirmModal({ onCancel, onDelete, role, abortReason, setAbortReason }: ConfirmModalProps) {
   return (
     <div className="fixed top-0 left-0 w-full h-full bg-gray-900 bg-opacity-50 z-30">
-      <div className="flex fixed max-w-[29.8rem] top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 flex-col justify-center items-center w-full rounded-[1.2rem] p-[2.4rem] bg-primary-white gap-[1.5rem] z-11">
+      <div className="flex fixed max-w-[29.8rem] top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 flex-col justify-center items-center w-full rounded-[1.2rem] p-[2.4rem] bg-primary-white gap-[1.5rem]">
         <div className="flex-col justify-center items-center mb-[1.5rem]">
           <div className="flex justify-center mb-[1.5rem]">
             <Image src={check} alt="체크 이미지" width={24} height={24} />
           </div>
           <p className="text-[1.6rem] font-medium text-gray-700">Are you sure you want to cancel?</p>
         </div>
+        {role === 'admin' && abortReason !== undefined && setAbortReason && (
+          <div className="w-full mb-[1.5rem]">
+            <textarea
+              className="w-full text-[1.3rem] h-[16rem] p-[1rem] border rounded-[0.8rem] text-gray-700 focus:outline-none border-gray-300 resize-none"
+              placeholder="Enter reason for aborting..."
+              value={abortReason}
+              onChange={e => setAbortReason(e.target.value)}
+            />
+          </div>
+        )}
         <div className="flex gap-[0.8rem]">
           <button
             onClick={onCancel}

--- a/src/interfaces/modalInterface.ts
+++ b/src/interfaces/modalInterface.ts
@@ -8,6 +8,9 @@ export interface ClosableModalProps {
 export interface ConfirmModalProps {
   onCancel: () => void;
   onDelete: () => void;
+  role?: string | null;
+  abortReason?: string;
+  setAbortReason?: (reason: string) => void;
 }
 
 export interface ImageModalProps {


### PR DESCRIPTION
## 이슈 번호

- close #162 

## 작업 사항
- [x] 현재 프론트에서 onGoing, finished로 걸러주고 있는데, 리스트 받아오는데 문제가 생겨서 백엔드 측에서 만들어주면 아래와 같이 수정.
  - 챌린지 리스트 페이지 / 어드민 관리 페이지 두개로 API 나눠서 하기
- [x] 어드민챌린지는 백엔드 API 연결하기
- [x] modal에 admin일때만 abort reason 쓰는 textarea 만들기
  -  그러면 API 바로 작동 가능

## 기타
[챌린지 페이지]
- 챌린지 정렬 API CSR -> SSR 로직 변경
- page와pageSize 넘겨주는 거 고려해서 다시 수정하기
- 미디어 쿼리 적용하기
[챌린지 신청 페이지]
- 미디어 쿼리 적용하기

[알림]
- 웹 소켓 - socketio react 알림보내주기
  - 공부하기