### PR TITLE
normal 또는 admin 유저에 따라 페이지 접근 허용

### DIFF
--- a/src/app/me/challenge/[id]/page.tsx
+++ b/src/app/me/challenge/[id]/page.tsx
@@ -19,6 +19,13 @@ export default function AdminChallengeDetailClient() {
   const [currentData, setCurrentData] = useState<ChallengeApplicationDetailHeaderData | null>(null);
   const [currentPage, setCurrentPage] = useState<number>(1);
 
+  useEffect(() => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) {
+      router.push('/');
+    }
+  }, []);
+
   const itemsPerPage = 1;
   const totalPages =
     currentData && typeof currentData.number === 'number' ? Math.max(1, Math.ceil(challengeMgmtTotalCount / itemsPerPage)) : 1;

--- a/src/components/ClientWrapper/AdminChallengeDetailClient.tsx
+++ b/src/components/ClientWrapper/AdminChallengeDetailClient.tsx
@@ -14,9 +14,10 @@ import Pagination from '../Pagination/Pagination';
 export default function AdminChallengeDetailClient() {
   const { id } = useParams();
   const router = useRouter();
-  const { challengeMgmtTotalCount, id: userId, role } = useStore();
+  const { challengeMgmtTotalCount, role } = useStore();
   useEffect(() => {
-    if (!userId && role !== 'admin') {
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken || role !== 'admin') {
       router.push('/');
     }
   }, []);

--- a/src/components/ClientWrapper/AdminChallengeDetailClient.tsx
+++ b/src/components/ClientWrapper/AdminChallengeDetailClient.tsx
@@ -14,7 +14,12 @@ import Pagination from '../Pagination/Pagination';
 export default function AdminChallengeDetailClient() {
   const { id } = useParams();
   const router = useRouter();
-  const { challengeMgmtTotalCount } = useStore();
+  const { challengeMgmtTotalCount, id: userId, role } = useStore();
+  useEffect(() => {
+    if (!userId && role !== 'admin') {
+      router.push('/');
+    }
+  }, []);
 
   const [currentData, setCurrentData] = useState<ChallengeApplicationDetailHeaderData | null>(null);
   const [currentPage, setCurrentPage] = useState<number>(1);

--- a/src/components/ClientWrapper/ChallengeMgmtClient.tsx
+++ b/src/components/ClientWrapper/ChallengeMgmtClient.tsx
@@ -13,10 +13,11 @@ import ChallengeApplicationBody from '../Body/ChallengeApplicationBody';
 import Pagination from '../Pagination/Pagination';
 
 export default function ChallengeMgmtClient() {
-  const { id, role } = useStore();
+  const { role } = useStore();
   const router = useRouter();
   useEffect(() => {
-    if (!id && role !== 'admin') {
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken || role !== 'admin') {
       router.push('/');
     }
   }, []);

--- a/src/components/ClientWrapper/ChallengeMgmtClient.tsx
+++ b/src/components/ClientWrapper/ChallengeMgmtClient.tsx
@@ -2,6 +2,7 @@
 
 import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import loading from '@/../public/assets/Message@1x-1.0s-200px-200px.svg';
 import { fetchChallengeApplication } from '@/api/challengeService';
@@ -12,6 +13,13 @@ import ChallengeApplicationBody from '../Body/ChallengeApplicationBody';
 import Pagination from '../Pagination/Pagination';
 
 export default function ChallengeMgmtClient() {
+  const { id, role } = useStore();
+  const router = useRouter();
+  useEffect(() => {
+    if (!id && role !== 'admin') {
+      router.push('/');
+    }
+  }, []);
   const queryClient = useQueryClient();
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;

--- a/src/components/ClientWrapper/MyChallengeClient.tsx
+++ b/src/components/ClientWrapper/MyChallengeClient.tsx
@@ -18,6 +18,13 @@ export default function MyChallengeClient() {
 
   const { keyword, category, setKeyword, setCategory } = useStore();
 
+  useEffect(() => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) {
+      router.push('/');
+    }
+  }, []);
+
   const [activeTab, setActiveTab] = useState('participating');
 
   const [currentPage, setCurrentPage] = useState(1);


### PR DESCRIPTION
## 이슈 번호

- close #209 

## 작업 사항

- [x] 일반 멤버가 어드민 페이지 접근 못 하게
- [x] 로그인 하지 않은 유저가 일반 멤버 페이지, 어드민 페이지 접근 안 되게

## 기타

다음에 할 작업
- refreshToken 에러 해결
- 작업물 작성 후 조회할 때 데이터 파싱
- lighthouse 성능 개선