### PR TITLE
챌린지 리스트 정렬 SSR 로직 변경

### DIFF
--- a/src/components/ClientWrapper/ChallengeListClient.tsx
+++ b/src/components/ClientWrapper/ChallengeListClient.tsx
@@ -16,7 +16,7 @@ import MonthlyRankerCard from '../Card/MonthlyRankerCard';
 import FilterBar from '../FilterBar/FilterBar';
 import Pagination from '../Pagination/Pagination';
 
-export default function ChallengeListClient({ adminchallengeData, challengeData, rankerData }: ChallengeListClientProps) {
+export default function ChallengeListClient({ adminchallengeData, rankerData }: ChallengeListClientProps) {
   const router = useRouter();
   const { id, role, keyword, setKeyword } = useStore();
   const [currentPage, setCurrentPage] = useState(1);
@@ -37,16 +37,10 @@ export default function ChallengeListClient({ adminchallengeData, challengeData,
     };
   });
 
-  const [medium, setMedium] = useState<ChallengeData[]>(challengeData);
   const [orderBy, setOrderBy] = useState<string>('');
   const [mediaType, setMediaType] = useState<string[]>([]);
   const [status, setStatus] = useState<string>('');
-  const [selectedCount, setSelectedCount] = useState<number>(0);
-  const [isFilterApplied, setIsFilterApplied] = useState<boolean>(false);
 
-  const indexOfLastItem = currentPage * itemsPerPage;
-  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
-  const mediumItems = medium.slice(indexOfFirstItem, indexOfLastItem);
   const queryClient = useQueryClient();
 
   const createQueryParams = (orderBy: string, mediaType: string[], status: string, keyword: string): string => {
@@ -119,10 +113,6 @@ export default function ChallengeListClient({ adminchallengeData, challengeData,
     setOrderBy(orderBy);
     setMediaType(mediaType);
     setStatus(status);
-
-    const count = (orderBy ? 1 : 0) + mediaType.length + (status ? 1 : 0);
-    setSelectedCount(count);
-    setIsFilterApplied(count > 0);
 
     if (!orderBy && mediaType.length === 0 && !status) {
       window.location.reload();

--- a/src/components/ClientWrapper/ChallengeListClient.tsx
+++ b/src/components/ClientWrapper/ChallengeListClient.tsx
@@ -115,7 +115,9 @@ export default function ChallengeListClient({ adminchallengeData, rankerData }: 
     setStatus(status);
 
     if (!orderBy && mediaType.length === 0 && !status) {
-      window.location.reload();
+      setOrderBy('');
+      setMediaType([]);
+      setStatus('');
       return;
     }
   };

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -160,7 +160,7 @@ export default function Dropdown({ isOpen, items, onSelect, type, onApply, onClo
   return (
     <div className={`absolute ${dropdownType} mt-[0.8rem]`}>
       {isOpen && (
-        <div className="flex items-center justify-center flex-col rounded-[0.8rem] bg-[#ffffff] border border-gray-300">
+        <div className="flex items-center justify-center flex-col rounded-[0.8rem] bg-primary-white border border-gray-300">
           {renderItems()}
         </div>
       )}

--- a/src/components/FilterBar/FilterBar.tsx
+++ b/src/components/FilterBar/FilterBar.tsx
@@ -114,7 +114,7 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
       const currentKeyword = e.currentTarget.value.trim();
       setKeyword(currentKeyword || '');
       if (!currentKeyword) {
-        window.location.reload();
+        setKeyword('');
         return;
       }
     }

--- a/src/components/FilterBar/FilterBar.tsx
+++ b/src/components/FilterBar/FilterBar.tsx
@@ -16,7 +16,7 @@ const filterBarWidths = {
 };
 
 const sortBarWidths = {
-  challenge: 'lg:w-[14rem] md:w-[12.1rem] sm:w-[10rem]',
+  challenge: 'lg:w-[14rem] md:w-[12.1rem] sm:w-[10.9rem]',
   admin: 'w-[18.1rem]'
 };
 
@@ -81,7 +81,7 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
 
   const getSelectedSortLabel = () => {
     if (isFilterApplied) {
-      return `Filtered (${selectedCount})`;
+      return `Filtered(${selectedCount})`;
     }
     if (type === 'admin' && selectedSort) {
       const adminOptions = optionsByType.admin;
@@ -141,19 +141,19 @@ export default function FilterBar({ type, onFilterApply }: FilterBarProps) {
 
   return (
     <div className="z-20">
-      <div className={`h-[4rem] gap-[1.2rem] justify-between items-center flex ${filterBarType}`}>
+      <div className={`h-[4rem] md:gap-[2rem] sm:gap-[0.6rem] justify-between items-center flex ${filterBarType}`}>
         <div
-          className={`flex justify-between items-center h-full rounded-[0.8rem] border border-gray-200 px-[1.2rem] py-[0.8rem] gap-[1rem] cursor-pointer ${sortBarType}
+          className={`flex justify-between items-center rounded-[0.8rem] border border-gray-200 px-[1.2rem] py-[0.8rem] cursor-pointer ${sortBarType}
             ${isFilterApplied ? 'bg-gray-700' : 'bg-primary-white'}`}
           onClick={handleToggleDropdown}
         >
           <p
-            className={`font-normal text-[1.6rem] leading-[1.909rem] 
+            className={`font-normal lg:text-[1.6rem] sm:text-[1.4rem] leading-[1.909rem] 
             ${isFilterApplied ? 'text-primary-white' : 'text-gray-400'} ${type === 'admin' && getSelectedSortLabel() === 'Sort' ? 'text-gray-400' : 'text-gray-700'}`}
           >
             {getSelectedSortLabel()}
           </p>
-          <Image src={isFilterApplied ? activeFilter : filter} alt="깔때기" />
+          <Image src={isFilterApplied ? activeFilter : filter} alt="깔때기" width={16} height={16} layout="fixed" />
         </div>
         <div
           className={`h-full border border-gray-200 rounded-[2rem] flex items-center gap-[0.4rem] p-[0.4rem] bg-primary-white ${searchBarType}`}

--- a/src/interfaces/challengelistInterface.ts
+++ b/src/interfaces/challengelistInterface.ts
@@ -2,7 +2,6 @@ import type { ChallengeData, MonthlyChallengeData, MonthlyRankerCard, requestUse
 
 export interface ChallengeListClientProps {
   adminchallengeData: MonthlyChallengeData[];
-  challengeData: ChallengeData[];
   rankerData: MonthlyRankerCard[];
 }
 


### PR DESCRIPTION
## 이슈 번호

- close #216 

## 작업 사항
- [x] 챌린지 정렬 API CSR -> SSR 로직 변경
- [x] 키워드 비어있을 때, 드롭다운 선택 비어있을 때 새로고침 X -> 그 상태를 검색하도록.
- [x] 필터바 filtered(숫자) 되었을 때 두줄 되는 문제 해결.

## 기타
### 다음 작업 사항
[유지보수]
- 지속적으로 테스트해서 문제 해결하기
  - css
  - 기능
  - 성능

[라우터]
- 라우터 접근 제한 설정 (권한에 따라) 모든 페이지 하고, 체크 하기