### PR TITLE
알림 컴포넌트 제작

### DIFF
--- a/src/components/Modal/NotificationModal.tsx
+++ b/src/components/Modal/NotificationModal.tsx
@@ -1,0 +1,36 @@
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import closeImg from '@/../public/assets/ic_out.png';
+import type { NotificationModalProps } from '@/interfaces/modalInterface';
+import useStore from '@/store/store';
+
+export default function ProfileModal({}: NotificationModalProps) {
+  const router = useRouter();
+
+  const notifications = [
+    { content: '새로운 알림입니다.', time: '2024-12-04 10:30:00' },
+    { content: '업데이트가 완료되었습니다.', time: '2024-12-04 09:45:00' }
+  ];
+
+  return (
+    <div className="w-full h-full">
+      <div className="w-[34.3rem] h-[51.9rem] bg-primary-white rounded-[0.8rem] border-2 border-gray-200 flex flex-col">
+        <div className="flex justify-between p-[1.6rem]">
+          <p className="text-gray-700 font-semibold text-[1.6rem]">Notification</p>
+          <Image src={closeImg} alt="close" width={24} height={24} />
+        </div>
+        <div className="flex flex-col">
+          {notifications.map((notification, index) => (
+            <div key={index}>
+              <div className="flex flex-col gap-[1rem] px-[1.6rem] py-[1.2rem]">
+                <div className="text-[1.4rem] leading-[1.671rem] text-gray-700">{notification.content}</div>
+                <div className="text-[1.4rem] leading-[1.671rem] text-gray-400">{notification.time}</div>
+              </div>
+              {index < notifications.length - 1 && <hr className="border-gray-200" />}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Modal/NotificationModal.tsx
+++ b/src/components/Modal/NotificationModal.tsx
@@ -1,30 +1,31 @@
+import { format } from 'date-fns';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
-import closeImg from '@/../public/assets/ic_out.png';
+import closeImg from '@/../public/assets/icon_close.png';
 import type { NotificationModalProps } from '@/interfaces/modalInterface';
 import useStore from '@/store/store';
 
-export default function ProfileModal({}: NotificationModalProps) {
-  const router = useRouter();
-
-  const notifications = [
-    { content: '새로운 알림입니다.', time: '2024-12-04 10:30:00' },
-    { content: '업데이트가 완료되었습니다.', time: '2024-12-04 09:45:00' }
-  ];
+export default function ProfileModal({ notifications }: NotificationModalProps) {
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) {
+      return '';
+    }
+    return format(date, 'yyyy-MM-dd HH:mm:ss');
+  };
 
   return (
     <div className="w-full h-full">
       <div className="w-[34.3rem] h-[51.9rem] bg-primary-white rounded-[0.8rem] border-2 border-gray-200 flex flex-col">
-        <div className="flex justify-between p-[1.6rem]">
+        <div className="flex justify-between p-[1.6rem] ">
           <p className="text-gray-700 font-semibold text-[1.6rem]">Notification</p>
           <Image src={closeImg} alt="close" width={24} height={24} />
         </div>
-        <div className="flex flex-col">
-          {notifications.map((notification, index) => (
+        <div className="flex flex-col overflow-y-auto h-[45.5rem]">
+          {notifications.map((data, index) => (
             <div key={index}>
               <div className="flex flex-col gap-[1rem] px-[1.6rem] py-[1.2rem]">
-                <div className="text-[1.4rem] leading-[1.671rem] text-gray-700">{notification.content}</div>
-                <div className="text-[1.4rem] leading-[1.671rem] text-gray-400">{notification.time}</div>
+                <div className="text-[1.4rem] leading-[1.671rem] text-gray-700">{data.content}</div>
+                <div className="text-[1.4rem] leading-[1.671rem] text-gray-400">{formatDate(data.time)}</div>
               </div>
               {index < notifications.length - 1 && <hr className="border-gray-200" />}
             </div>

--- a/src/components/Modal/NotificationModal.tsx
+++ b/src/components/Modal/NotificationModal.tsx
@@ -15,12 +15,12 @@ export default function ProfileModal({ notifications }: NotificationModalProps) 
 
   return (
     <div className="w-full h-full">
-      <div className="w-[34.3rem] h-[51.9rem] bg-primary-white rounded-[0.8rem] border-2 border-gray-200 flex flex-col">
+      <div className="md:w-[34.3rem] sm:w-[27rem] md:h-[51.9rem] sm:h-[35rem] bg-primary-white rounded-[0.8rem] border-2 border-gray-200 flex flex-col">
         <div className="flex justify-between p-[1.6rem] ">
           <p className="text-gray-700 font-semibold text-[1.6rem]">Notification</p>
           <Image src={closeImg} alt="close" width={24} height={24} />
         </div>
-        <div className="flex flex-col overflow-y-auto h-[45.5rem]">
+        <div className="flex flex-col overflow-y-auto md:h-[45.5rem] sm:h-[23.6rem]">
           {notifications.map((data, index) => (
             <div key={index}>
               <div className="flex flex-col gap-[1rem] px-[1.6rem] py-[1.2rem]">

--- a/src/components/Modal/NotificationModal.tsx
+++ b/src/components/Modal/NotificationModal.tsx
@@ -4,7 +4,7 @@ import closeImg from '@/../public/assets/icon_close.png';
 import type { NotificationModalProps } from '@/interfaces/modalInterface';
 import useStore from '@/store/store';
 
-export default function ProfileModal({ notifications }: NotificationModalProps) {
+export default function ProfileModal({ notifications, onClose }: NotificationModalProps) {
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
     if (isNaN(date.getTime())) {
@@ -18,7 +18,7 @@ export default function ProfileModal({ notifications }: NotificationModalProps) 
       <div className="md:w-[34.3rem] sm:w-[27rem] md:h-[51.9rem] sm:h-[35rem] bg-primary-white rounded-[0.8rem] border-2 border-gray-200 flex flex-col">
         <div className="flex justify-between p-[1.6rem] ">
           <p className="text-gray-700 font-semibold text-[1.6rem]">Notification</p>
-          <Image src={closeImg} alt="close" width={24} height={24} />
+          <Image src={closeImg} alt="close" width={24} height={24} className="cursor-pointer" onClick={onClose} />
         </div>
         <div className="flex flex-col overflow-y-auto md:h-[45.5rem] sm:h-[23.6rem]">
           {notifications.map((data, index) => (

--- a/src/components/Modal/ProfileModal.tsx
+++ b/src/components/Modal/ProfileModal.tsx
@@ -32,7 +32,7 @@ export default function ProfileModal({ name, role }: ProfileModalProps) {
             <p className="font-medium text-[1.2rem] leading-[1.432rem] text-gray-500">{userRole}</p>
           </div>
         </div>
-        <div className="border border-gray-200 w-full" /> {/* 직선 */}
+        <div className="border border-gray-200 w-full" />
         <div className="flex flex-col gap-[1.2rem]">
           {isMem ? (
             <p className="font-medium text-[1.6rem] leading-[1.909rem] text-gray-600" onClick={handleRouteMyPage}>

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import bell from '@/../public/assets/icon_bell_default.png';
 import translate from '@/../public/assets/icon_translate.png';
 import logo from '@/../public/assets/img_logo_pc.png';
@@ -28,10 +28,16 @@ export default function Nav() {
 
   const { name, role } = useStore();
 
+  // TODO Socket 통신으로 데이터 받아오는 거 변경하기
   const notifications = [
-    { content: '새로운 알림입니다.', time: '2024-12-04 10:30:00' },
-    { content: '업데이트가 완료되었습니다.', time: '2024-12-04 09:45:00' }
+    { content: '새로운 알림입니다.', time: '2024-12-04T08:29:07.703Z' },
+    { content: '업데이트가 완료되었습니다.', time: '2024-12-04T06:39:07.703Z' }
   ];
+
+  useEffect(() => {
+    setIsNotificationModalOpen(false);
+    setIsProfileModalOpen(false);
+  }, [pathname]);
 
   return (
     <div className="w-full h-full flex justify-center">
@@ -87,7 +93,7 @@ export default function Nav() {
                     <Image src={bell} alt="벨" onClick={() => setIsNotificationModalOpen(!isNotificationModalOpen)} />
                     {isNotificationModalOpen && (
                       <div className="z-[30] absolute right-0 top-full mt-[1.2rem]">
-                        {/* socket 연결해서 데이터 받기 notifications={notifications} */}
+                        {/* socket 연결해서 데이터 받기*/}
                         <NotificationModal notifications={notifications} onClose={() => setIsNotificationModalOpen(false)} />
                       </div>
                     )}

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -88,8 +88,7 @@ export default function Nav() {
                     {isNotificationModalOpen && (
                       <div className="z-[30] absolute right-0 top-full mt-[1.2rem]">
                         {/* socket 연결해서 데이터 받기 notifications={notifications} */}
-                        {/* 닫기 버튼 onClose={() => setIsModalOpen(false)} */}
-                        <NotificationModal notifications={notifications} />
+                        <NotificationModal notifications={notifications} onClose={() => setIsNotificationModalOpen(false)} />
                       </div>
                     )}
                   </div>

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -10,6 +10,7 @@ import adminProfile from '@/../public/assets/img_profile_admin.png';
 import userProfile from '@/../public/assets/img_profile_member.png';
 import useStore from '@/store/store';
 import ClosableModalClient from '../ClientWrapper/ClosableModalClient';
+import NotificationModal from '../Modal/NotificationModal';
 import ProfileModal from '../Modal/ProfileModal';
 
 export default function Nav() {
@@ -22,9 +23,15 @@ export default function Nav() {
   const isMgmt = pathname.startsWith('/auth');
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
 
   const { name, role } = useStore();
+
+  const notifications = [
+    { content: '새로운 알림입니다.', time: '2024-12-04 10:30:00' },
+    { content: '업데이트가 완료되었습니다.', time: '2024-12-04 09:45:00' }
+  ];
 
   return (
     <div className="w-full h-full flex justify-center">
@@ -76,7 +83,16 @@ export default function Nav() {
               <Image src={translate} alt="번역" onClick={() => setIsModalOpen(true)} width={24} height={24} />
               {userStatus === 'normal' ? (
                 <>
-                  <Image src={bell} alt="벨" />
+                  <div className="relative">
+                    <Image src={bell} alt="벨" onClick={() => setIsNotificationModalOpen(!isNotificationModalOpen)} />
+                    {isNotificationModalOpen && (
+                      <div className="z-[30] absolute right-0 top-full mt-[1.2rem]">
+                        {/* socket 연결해서 데이터 받기 notifications={notifications} */}
+                        {/* 닫기 버튼 onClose={() => setIsModalOpen(false)} */}
+                        <NotificationModal notifications={notifications} />
+                      </div>
+                    )}
+                  </div>
                   <div className="relative">
                     <Image
                       src={userProfile}

--- a/src/interfaces/modalInterface.ts
+++ b/src/interfaces/modalInterface.ts
@@ -19,3 +19,5 @@ export interface ImageModalProps {
   alt: string;
   onClose: () => void;
 }
+
+export interface NotificationModalProps {}

--- a/src/interfaces/modalInterface.ts
+++ b/src/interfaces/modalInterface.ts
@@ -20,4 +20,11 @@ export interface ImageModalProps {
   onClose: () => void;
 }
 
-export interface NotificationModalProps {}
+export interface NotificationModalProps {
+  notifications: Notification[];
+}
+
+export interface Notification {
+  content: string;
+  time: string;
+}

--- a/src/interfaces/modalInterface.ts
+++ b/src/interfaces/modalInterface.ts
@@ -22,6 +22,7 @@ export interface ImageModalProps {
 
 export interface NotificationModalProps {
   notifications: Notification[];
+  onClose: () => void;
 }
 
 export interface Notification {

--- a/src/stories/NotificationModal.stories.tsx
+++ b/src/stories/NotificationModal.stories.tsx
@@ -1,0 +1,33 @@
+import type { StoryFn } from '@storybook/react';
+import NotificationModal from '@/components/Modal/NotificationModal';
+import type { NotificationModalProps } from '@/interfaces/modalInterface';
+
+export default {
+  title: 'NotificationModal',
+  component: NotificationModal
+};
+
+const Template: StoryFn<NotificationModalProps> = args => <NotificationModal {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  args: {}
+};
+
+export const EmptyNotifications = Template.bind({});
+EmptyNotifications.args = {
+  args: {
+    notifications: []
+  }
+};
+
+export const MultipleNotifications = Template.bind({});
+MultipleNotifications.args = {
+  args: {
+    notifications: [
+      { content: '새로운 알림입니다.', time: '2024-12-04 10:30:00' },
+      { content: '업데이트가 완료되었습니다.', time: '2024-12-04 09:45:00' },
+      { content: '시스템 점검이 예정되어 있습니다.', time: '2024-12-03 17:20:00' }
+    ]
+  }
+};

--- a/src/stories/NotificationModal.stories.tsx
+++ b/src/stories/NotificationModal.stories.tsx
@@ -11,23 +11,29 @@ const Template: StoryFn<NotificationModalProps> = args => <NotificationModal {..
 
 export const Default = Template.bind({});
 Default.args = {
-  args: {}
+  notifications: []
 };
 
 export const EmptyNotifications = Template.bind({});
 EmptyNotifications.args = {
-  args: {
-    notifications: []
-  }
+  notifications: []
 };
 
 export const MultipleNotifications = Template.bind({});
 MultipleNotifications.args = {
-  args: {
-    notifications: [
-      { content: '새로운 알림입니다.', time: '2024-12-04 10:30:00' },
-      { content: '업데이트가 완료되었습니다.', time: '2024-12-04 09:45:00' },
-      { content: '시스템 점검이 예정되어 있습니다.', time: '2024-12-03 17:20:00' }
-    ]
-  }
+  notifications: [
+    { content: '새로운 알림입니다.', time: '2024-12-04T06:39:07.703Z' },
+    { content: '업데이트가 완료되었습니다.', time: '2024-12-04T06:45:07.703Z' },
+    { content: '시스템 점검이 예정되어 있습니다.', time: '2024-12-04T08:29:07.703Z' },
+    { content: '새로운 알림입니다.', time: '2024-12-04T06:39:07.703Z' },
+    { content: '업데이트가 완료되었습니다.', time: '2024-12-04T06:45:07.703Z' },
+    {
+      content:
+        '시스템 점검이 예정되어 있습니다.시스템 점검이 예정되어 있습니다.시스템 점검이 예정되어 있습니다.시스템 점검이 예정되어 있습니다.시스템 점검이 예정되어 있습니다.',
+      time: '2024-12-04T08:29:07.703Z'
+    },
+    { content: '새로운 알림입니다.', time: '2024-12-04T06:39:07.703Z' },
+    { content: '업데이트가 완료되었습니다.', time: '2024-12-04T06:45:07.703Z' },
+    { content: '시스템 점검이 예정되어 있습니다.', time: '2024-12-04T08:29:07.703Z' }
+  ]
 };


### PR DESCRIPTION
## 이슈 번호
- close #203 

[[socket.io](http://socket.io/) 실시간 알림]
1. 챌린지가 종료 되었을 때 (onGoing -> finished)
2. 신청한 챌린지가 approved or rejected 되었을 때
  - 거절하면 거절 사유 포함.
3. 내 작업물에 댓글 달렸을 때
4. 내가 참여하고 있는 챌린지에 새로운 작업물이 생길 때
5. 알림 전송 시간 받기


## 작업 사항
![Screenshot 2024-12-04 at 17 24 53](https://github.com/user-attachments/assets/f9c2e9cc-1cc3-4859-be76-d6238247cc32)

[알림 드롭다운 컴포넌트]
- [x] 컴포넌트 만들기
- [x] 스토리북 만들기
- [x] 알림 아이콘에 연결하기
- [x] 페이지 이동하면 프로필 모달이랑 알림 모달 닫기게 수정
- [x] createdAt 시간 UTC 시간이라서 한국 시간으로 바꾸기

[웹 소켓 - socketio 알림]
- [x] Client API & 튜토리얼 공부하기 완료

## 기타
### 다음 작업 사항
[알림 드롭다운 컴포넌트 심화]
- 알림 오면 알림 이미지 옆에 점 생겨서 표시
- 알림 온 거 한번 누르면(확인하면) 표시해주기
- 누르면 관련 페이지로 이동하게

[웹 소켓 - socketio 알림]
- 로그인 할 때 토큰 실시간으로 보내기
- 알림 이벤트 수신

[유지보수]
- 지속적으로 테스트해서 문제 해결하기
  - css
  - 기능
  - 성능

[라우터]
- 라우터 접근 제한 설정 (권한에 따라)